### PR TITLE
feat: Cedar policy generation from validators and tool policies

### DIFF
--- a/internal/agentcore/aws_client.go
+++ b/internal/agentcore/aws_client.go
@@ -10,6 +10,12 @@ type awsClient interface {
 	CreateA2AWiring(ctx context.Context, name string, cfg *Config) (arn string, err error)
 	CreateEvaluator(ctx context.Context, name string, cfg *Config) (arn string, err error)
 	CreateMemory(ctx context.Context, name string, cfg *Config) (arn string, err error)
+	CreatePolicyEngine(ctx context.Context, name string, cfg *Config) (
+		arn string, engineID string, err error,
+	)
+	CreateCedarPolicy(ctx context.Context, engineID string, name string,
+		cedarStatement string, cfg *Config) (arn string, policyID string, err error,
+	)
 }
 
 // resourceDestroyer abstracts resource deletion so that real AWS calls

--- a/internal/agentcore/aws_client_simulated_test.go
+++ b/internal/agentcore/aws_client_simulated_test.go
@@ -43,6 +43,22 @@ func (c *simulatedAWSClient) CreateMemory(_ context.Context, name string, _ *Con
 	return fmt.Sprintf("arn:aws:bedrock:%s:%s:memory/%s", c.region, c.accountID, name), nil
 }
 
+func (c *simulatedAWSClient) CreatePolicyEngine(
+	_ context.Context, name string, _ *Config,
+) (string, string, error) {
+	arn := fmt.Sprintf("arn:aws:bedrock:%s:%s:policy-engine/%s", c.region, c.accountID, name)
+	engineID := "pe-" + name
+	return arn, engineID, nil
+}
+
+func (c *simulatedAWSClient) CreateCedarPolicy(
+	_ context.Context, engineID string, name string, _ string, _ *Config,
+) (string, string, error) {
+	arn := fmt.Sprintf("arn:aws:bedrock:%s:%s:policy/%s/%s", c.region, c.accountID, engineID, name)
+	policyID := "pol-" + name
+	return arn, policyID, nil
+}
+
 // simulatedDestroyer is a placeholder that logs intent without calling AWS.
 type simulatedDestroyer struct{}
 

--- a/internal/agentcore/cedar.go
+++ b/internal/agentcore/cedar.go
@@ -1,0 +1,232 @@
+package agentcore
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+)
+
+// generateCedarStatement builds a single Cedar policy statement from the
+// given validators and tool policy. Returns an empty string if there are
+// no rules to generate.
+func generateCedarStatement(
+	validators []prompt.ValidatorConfig,
+	tp *prompt.ToolPolicyPack,
+) string {
+	var blocks []string
+
+	for _, v := range validators {
+		block := cedarFromValidator(v)
+		if block != "" {
+			blocks = append(blocks, block)
+		}
+	}
+
+	if tp != nil {
+		blocks = append(blocks, cedarFromToolPolicy(tp)...)
+	}
+
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	return strings.Join(blocks, "\n\n")
+}
+
+// cedarFromValidator dispatches to the appropriate Cedar generator based
+// on validator type.
+func cedarFromValidator(v prompt.ValidatorConfig) string {
+	annotation := cedarAnnotation(v.FailOnViolation)
+
+	switch v.Type {
+	case "banned_words":
+		return cedarBannedWords(v.Params, annotation)
+	case "max_length":
+		return cedarMaxLength(v.Params, annotation)
+	case "regex_match":
+		return cedarRegexMatch(v.Params, annotation)
+	case "json_schema":
+		return cedarJSONSchema(v.Params, annotation)
+	default:
+		return fmt.Sprintf(
+			"%s// unsupported validator type: %s",
+			annotation, v.Type,
+		)
+	}
+}
+
+// cedarAnnotation returns a comment prefix for observe-only rules.
+func cedarAnnotation(failOnViolation *bool) string {
+	if failOnViolation != nil && !*failOnViolation {
+		return "// observe-only\n"
+	}
+	return ""
+}
+
+// cedarBannedWords generates a forbid block for each banned word.
+func cedarBannedWords(params map[string]interface{}, annotation string) string {
+	wordsRaw, ok := params["words"]
+	if !ok {
+		return ""
+	}
+	wordSlice, ok := wordsRaw.([]interface{})
+	if !ok {
+		return ""
+	}
+
+	var blocks []string
+	for _, w := range wordSlice {
+		word, ok := w.(string)
+		if !ok {
+			continue
+		}
+		blocks = append(blocks, fmt.Sprintf(
+			`%sforbid (principal, action, resource)
+when { context.output like "*%s*" };`,
+			annotation, escapeCedarLike(word),
+		))
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+// cedarMaxLength generates a forbid block for output length limits.
+func cedarMaxLength(params map[string]interface{}, annotation string) string {
+	maxChars, ok := extractInt(params, "max_characters")
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(
+		`%sforbid (principal, action, resource)
+when { context.output_length > %d };`,
+		annotation, maxChars,
+	)
+}
+
+// cedarRegexMatch generates a forbid block for regex pattern violations.
+func cedarRegexMatch(params map[string]interface{}, annotation string) string {
+	pattern, ok := params["pattern"].(string)
+	if !ok || pattern == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		`%sforbid (principal, action, resource)
+when { !context.output.matches("%s") };`,
+		annotation, escapeCedarString(pattern),
+	)
+}
+
+// cedarJSONSchema generates a comment-only placeholder since Cedar has no
+// native JSON Schema support.
+func cedarJSONSchema(_ map[string]interface{}, annotation string) string {
+	return fmt.Sprintf(
+		`%s// json_schema validation: enforced at runtime (no native Cedar support)`,
+		annotation,
+	)
+}
+
+// cedarFromToolPolicy generates Cedar forbid blocks from tool policy fields.
+func cedarFromToolPolicy(tp *prompt.ToolPolicyPack) []string {
+	var blocks []string
+
+	for _, tool := range tp.Blocklist {
+		blocks = append(blocks, cedarToolBlocklist(tool))
+	}
+
+	if tp.MaxRounds > 0 {
+		blocks = append(blocks, cedarMaxRounds(tp.MaxRounds))
+	}
+
+	if tp.MaxToolCallsPerTurn > 0 {
+		blocks = append(blocks, cedarMaxToolCallsPerTurn(tp.MaxToolCallsPerTurn))
+	}
+
+	return blocks
+}
+
+// cedarToolBlocklist generates a forbid block for a blocked tool.
+func cedarToolBlocklist(toolName string) string {
+	return fmt.Sprintf(
+		`forbid (principal, action == Action::"invoke_tool", resource)
+when { resource.tool_name == "%s" };`,
+		escapeCedarString(toolName),
+	)
+}
+
+// cedarMaxRounds generates a forbid block for max agentic loop rounds.
+func cedarMaxRounds(n int) string {
+	return fmt.Sprintf(
+		`forbid (principal, action == Action::"tool_loop_continue", resource)
+when { context.round_count > %d };`,
+		n,
+	)
+}
+
+// cedarMaxToolCallsPerTurn generates a forbid block for max tool calls per turn.
+func cedarMaxToolCallsPerTurn(n int) string {
+	return fmt.Sprintf(
+		`forbid (principal, action == Action::"invoke_tool", resource)
+when { context.tool_calls_this_turn > %d };`,
+		n,
+	)
+}
+
+// policyResourceNames returns a sorted list of prompt names that have
+// validators or tool_policy defined. Used by both plan and apply.
+func policyResourceNames(pack *prompt.Pack) []string {
+	var names []string
+	for name, p := range pack.Prompts {
+		if hasPolicyRules(p) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// hasPolicyRules returns true if the prompt has validators or a tool policy.
+func hasPolicyRules(p *prompt.PackPrompt) bool {
+	if len(p.Validators) > 0 {
+		return true
+	}
+	if p.ToolPolicy != nil {
+		tp := p.ToolPolicy
+		if len(tp.Blocklist) > 0 || tp.MaxRounds > 0 || tp.MaxToolCallsPerTurn > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// escapeCedarLike escapes characters that have special meaning in Cedar
+// like-expressions (wildcards * and %).
+func escapeCedarLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `*`, `\*`)
+	return s
+}
+
+// escapeCedarString escapes double quotes and backslashes in Cedar strings.
+func escapeCedarString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
+// extractInt extracts an integer value from a map[string]interface{}.
+// JSON numbers are typically decoded as float64.
+func extractInt(params map[string]interface{}, key string) (int, bool) {
+	v, ok := params[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/agentcore/cedar_test.go
+++ b/internal/agentcore/cedar_test.go
@@ -1,0 +1,304 @@
+package agentcore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+	"github.com/AltairaLabs/PromptKit/runtime/validators"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestCedarBannedWords(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "banned_words",
+			Params: map[string]interface{}{"words": []interface{}{"badword", "evil"}},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, `context.output like "*badword*"`) {
+		t.Errorf("expected banned word 'badword' in output, got:\n%s", result)
+	}
+	if !strings.Contains(result, `context.output like "*evil*"`) {
+		t.Errorf("expected banned word 'evil' in output, got:\n%s", result)
+	}
+	if !strings.Contains(result, "forbid") {
+		t.Error("expected forbid keyword")
+	}
+}
+
+func TestCedarBannedWords_ObserveOnly(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "banned_words",
+			Params: map[string]interface{}{"words": []interface{}{"test"}},
+		},
+		FailOnViolation: boolPtr(false),
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, "// observe-only") {
+		t.Errorf("expected observe-only annotation, got:\n%s", result)
+	}
+}
+
+func TestCedarMaxLength(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "max_length",
+			Params: map[string]interface{}{"max_characters": float64(500)},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, "context.output_length > 500") {
+		t.Errorf("expected max_length rule, got:\n%s", result)
+	}
+}
+
+func TestCedarRegexMatch(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "regex_match",
+			Params: map[string]interface{}{"pattern": `^[A-Z].*\.$`},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, "context.output.matches") {
+		t.Errorf("expected regex_match rule, got:\n%s", result)
+	}
+}
+
+func TestCedarJSONSchema(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "json_schema",
+			Params: map[string]interface{}{"schema": map[string]interface{}{"type": "object"}},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, "json_schema validation") {
+		t.Errorf("expected json_schema placeholder, got:\n%s", result)
+	}
+}
+
+func TestCedarToolBlocklist(t *testing.T) {
+	tp := &prompt.ToolPolicyPack{
+		Blocklist: []string{"dangerous_tool", "risky_tool"},
+	}
+	result := generateCedarStatement(nil, tp)
+
+	if !strings.Contains(result, `resource.tool_name == "dangerous_tool"`) {
+		t.Errorf("expected blocklist rule for dangerous_tool, got:\n%s", result)
+	}
+	if !strings.Contains(result, `resource.tool_name == "risky_tool"`) {
+		t.Errorf("expected blocklist rule for risky_tool, got:\n%s", result)
+	}
+	if !strings.Contains(result, `Action::"invoke_tool"`) {
+		t.Error("expected invoke_tool action")
+	}
+}
+
+func TestCedarMaxRounds(t *testing.T) {
+	tp := &prompt.ToolPolicyPack{
+		MaxRounds: 5,
+	}
+	result := generateCedarStatement(nil, tp)
+
+	if !strings.Contains(result, "context.round_count > 5") {
+		t.Errorf("expected max_rounds rule, got:\n%s", result)
+	}
+	if !strings.Contains(result, `Action::"tool_loop_continue"`) {
+		t.Error("expected tool_loop_continue action")
+	}
+}
+
+func TestCedarMaxToolCallsPerTurn(t *testing.T) {
+	tp := &prompt.ToolPolicyPack{
+		MaxToolCallsPerTurn: 3,
+	}
+	result := generateCedarStatement(nil, tp)
+
+	if !strings.Contains(result, "context.tool_calls_this_turn > 3") {
+		t.Errorf("expected max_tool_calls_per_turn rule, got:\n%s", result)
+	}
+}
+
+func TestCedarMixed(t *testing.T) {
+	validators := []prompt.ValidatorConfig{
+		{
+			ValidatorConfig: validators.ValidatorConfig{
+				Type:   "banned_words",
+				Params: map[string]interface{}{"words": []interface{}{"secret"}},
+			},
+		},
+		{
+			ValidatorConfig: validators.ValidatorConfig{
+				Type:   "max_length",
+				Params: map[string]interface{}{"max_characters": float64(1000)},
+			},
+		},
+	}
+	tp := &prompt.ToolPolicyPack{
+		Blocklist: []string{"exec"},
+		MaxRounds: 10,
+	}
+	result := generateCedarStatement(validators, tp)
+
+	// All four rules should be present.
+	checks := []string{
+		`context.output like "*secret*"`,
+		"context.output_length > 1000",
+		`resource.tool_name == "exec"`,
+		"context.round_count > 10",
+	}
+	for _, check := range checks {
+		if !strings.Contains(result, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, result)
+		}
+	}
+}
+
+func TestCedarEmpty(t *testing.T) {
+	result := generateCedarStatement(nil, nil)
+	if result != "" {
+		t.Errorf("expected empty string for no rules, got:\n%s", result)
+	}
+}
+
+func TestCedarEmptyToolPolicy(t *testing.T) {
+	tp := &prompt.ToolPolicyPack{}
+	result := generateCedarStatement(nil, tp)
+	if result != "" {
+		t.Errorf("expected empty string for empty tool policy, got:\n%s", result)
+	}
+}
+
+func TestCedarUnsupportedValidator(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "custom_unknown",
+			Params: map[string]interface{}{},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+
+	if !strings.Contains(result, "unsupported validator type: custom_unknown") {
+		t.Errorf("expected unsupported comment, got:\n%s", result)
+	}
+}
+
+func TestPolicyResourceNames(t *testing.T) {
+	pack := &prompt.Pack{
+		Prompts: map[string]*prompt.PackPrompt{
+			"chat": {
+				Validators: []prompt.ValidatorConfig{
+					{ValidatorConfig: validators.ValidatorConfig{Type: "banned_words"}},
+				},
+			},
+			"nopolicy": {},
+			"tooled": {
+				ToolPolicy: &prompt.ToolPolicyPack{
+					Blocklist: []string{"bad"},
+				},
+			},
+		},
+	}
+
+	names := policyResourceNames(pack)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d: %v", len(names), names)
+	}
+	// Should be sorted.
+	if names[0] != "chat" || names[1] != "tooled" {
+		t.Errorf("expected [chat, tooled], got %v", names)
+	}
+}
+
+func TestPolicyResourceNames_NoPolicies(t *testing.T) {
+	pack := &prompt.Pack{
+		Prompts: map[string]*prompt.PackPrompt{
+			"chat": {},
+		},
+	}
+	names := policyResourceNames(pack)
+	if len(names) != 0 {
+		t.Errorf("expected 0 names, got %d", len(names))
+	}
+}
+
+func TestEscapeCedarLike(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"hello", "hello"},
+		{"hello*world", `hello\*world`},
+		{`back\slash`, `back\\slash`},
+	}
+	for _, tt := range tests {
+		got := escapeCedarLike(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeCedarLike(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestEscapeCedarString(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"hello", "hello"},
+		{`say "hi"`, `say \"hi\"`},
+		{`back\slash`, `back\\slash`},
+	}
+	for _, tt := range tests {
+		got := escapeCedarString(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeCedarString(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCedarBannedWords_MissingParams(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "banned_words",
+			Params: map[string]interface{}{},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+	if result != "" {
+		t.Errorf("expected empty for missing words param, got:\n%s", result)
+	}
+}
+
+func TestCedarMaxLength_MissingParams(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "max_length",
+			Params: map[string]interface{}{},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+	if result != "" {
+		t.Errorf("expected empty for missing max_characters param, got:\n%s", result)
+	}
+}
+
+func TestCedarRegexMatch_MissingPattern(t *testing.T) {
+	v := prompt.ValidatorConfig{
+		ValidatorConfig: validators.ValidatorConfig{
+			Type:   "regex_match",
+			Params: map[string]interface{}{},
+		},
+	}
+	result := generateCedarStatement([]prompt.ValidatorConfig{v}, nil)
+	if result != "" {
+		t.Errorf("expected empty for missing pattern param, got:\n%s", result)
+	}
+}

--- a/internal/agentcore/envvars.go
+++ b/internal/agentcore/envvars.go
@@ -7,13 +7,14 @@ import (
 
 // Environment variable keys injected into AgentCore runtimes.
 const (
-	EnvLogGroup       = "PROMPTPACK_LOG_GROUP"
-	EnvTracingEnabled = "PROMPTPACK_TRACING_ENABLED"
-	EnvMemoryStore    = "PROMPTPACK_MEMORY_STORE"
-	EnvMemoryID       = "PROMPTPACK_MEMORY_ID"
-	EnvA2AAgents      = "PROMPTPACK_AGENTS"
-	EnvA2AAuthMode    = "PROMPTPACK_A2A_AUTH_MODE"
-	EnvA2AAuthRole    = "PROMPTPACK_A2A_AUTH_ROLE"
+	EnvLogGroup        = "PROMPTPACK_LOG_GROUP"
+	EnvTracingEnabled  = "PROMPTPACK_TRACING_ENABLED"
+	EnvMemoryStore     = "PROMPTPACK_MEMORY_STORE"
+	EnvMemoryID        = "PROMPTPACK_MEMORY_ID"
+	EnvA2AAgents       = "PROMPTPACK_AGENTS"
+	EnvA2AAuthMode     = "PROMPTPACK_A2A_AUTH_MODE"
+	EnvA2AAuthRole     = "PROMPTPACK_A2A_AUTH_ROLE"
+	EnvPolicyEngineARN = "PROMPTPACK_POLICY_ENGINE_ARN"
 )
 
 // buildRuntimeEnvVars constructs the environment variable map that will be

--- a/internal/agentcore/state.go
+++ b/internal/agentcore/state.go
@@ -7,6 +7,14 @@ const (
 	ResTypeToolGateway  = "tool_gateway"
 	ResTypeA2AEndpoint  = "a2a_endpoint"
 	ResTypeEvaluator    = "evaluator"
+	ResTypeCedarPolicy  = "cedar_policy"
+)
+
+// Resource lifecycle status constants used in ResourceState.Status.
+const (
+	ResStatusCreated = "created"
+	ResStatusUpdated = "updated"
+	ResStatusFailed  = "failed"
 )
 
 // Health status constants returned by resource checks.

--- a/internal/agentcore/status.go
+++ b/internal/agentcore/status.go
@@ -11,6 +11,7 @@ import (
 // destroyOrder defines the reverse dependency order for teardown.
 // Resources are grouped by type; each group is destroyed in sequence.
 var destroyOrder = []string{
+	ResTypeCedarPolicy,
 	ResTypeEvaluator,
 	ResTypeA2AEndpoint,
 	ResTypeAgentRuntime,


### PR DESCRIPTION
## Summary

- Prompts with `validators` (banned_words, max_length, regex_match, json_schema) or `tool_policy` (blocklist, max_rounds, max_tool_calls_per_turn) now deploy as Cedar policy documents via AWS PolicyEngine + Policy resources
- Apply pipeline moves from 4 steps to 5: tools → **policies** → runtimes → a2a → evaluators (20% each)
- Policy engine ARNs are injected into runtimes via `PROMPTPACK_POLICY_ENGINE_ARN` env var
- New `cedar_policy` resource type with full plan/apply/destroy/status support
- Refactored `generateDesiredResources` to stay under cognitive complexity threshold

Closes #12, closes #13

## Test plan

- [x] Cedar generator tests (banned_words, max_length, regex_match, json_schema, tool blocklist, max_rounds, max_tool_calls_per_turn, mixed, empty, observe-only)
- [x] Apply with validators creates cedar_policy resources before runtimes
- [x] Apply with tool_policy creates cedar_policy resources
- [x] Apply without validators/tool_policy skips policy phase
- [x] Policy engine failure does not block runtime creation
- [x] Plan includes cedar_policy resources for prompts with validators
- [x] Plan excludes cedar_policy when no validators present
- [x] All 91 tests pass with `-race`
- [x] `golangci-lint` reports 0 issues
- [x] Pre-commit hook passes (goimports, lint, test, build)