### PR TITLE
feat: publish eval metrics config to CloudWatch (#15)

### DIFF
--- a/internal/agentcore/apply.go
+++ b/internal/agentcore/apply.go
@@ -72,6 +72,7 @@ func (p *Provider) prepareApply(
 	}
 
 	cfg.RuntimeEnvVars = buildRuntimeEnvVars(cfg)
+	injectMetricsConfig(cfg, pack)
 
 	return &applyContext{
 		pack:     pack,

--- a/internal/agentcore/envvars.go
+++ b/internal/agentcore/envvars.go
@@ -3,6 +3,8 @@ package agentcore
 import (
 	"encoding/json"
 	"strconv"
+
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
 )
 
 // Environment variable keys injected into AgentCore runtimes.
@@ -15,6 +17,7 @@ const (
 	EnvA2AAuthMode     = "PROMPTPACK_A2A_AUTH_MODE"
 	EnvA2AAuthRole     = "PROMPTPACK_A2A_AUTH_ROLE"
 	EnvPolicyEngineARN = "PROMPTPACK_POLICY_ENGINE_ARN"
+	EnvMetricsConfig   = "PROMPTPACK_METRICS_CONFIG"
 )
 
 // buildRuntimeEnvVars constructs the environment variable map that will be
@@ -64,4 +67,19 @@ func buildA2AEndpointMap(runtimeResources []ResourceState) string {
 	}
 	b, _ := json.Marshal(m)
 	return string(b)
+}
+
+// injectMetricsConfig builds the CloudWatch metrics configuration from pack
+// evals and sets it as an env var on the runtime config. No-op if no evals
+// define metrics.
+func injectMetricsConfig(cfg *Config, pack *prompt.Pack) {
+	mc := buildMetricsConfig(pack)
+	if mc == nil {
+		return
+	}
+	b, err := json.Marshal(mc)
+	if err != nil {
+		return
+	}
+	cfg.RuntimeEnvVars[EnvMetricsConfig] = string(b)
 }

--- a/internal/agentcore/metrics.go
+++ b/internal/agentcore/metrics.go
@@ -1,0 +1,103 @@
+package agentcore
+
+import (
+	"github.com/AltairaLabs/PromptKit/runtime/deploy/adaptersdk"
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+)
+
+// CloudWatch namespace for eval metrics.
+const metricsNamespace = "PromptPack/Evals"
+
+// CloudWatch unit strings mapped from MetricType.
+const (
+	unitNone         = "None"
+	unitCount        = "Count"
+	unitMilliseconds = "Milliseconds"
+)
+
+// MetricsConfig is the top-level CloudWatch metrics configuration
+// injected into runtimes via PROMPTPACK_METRICS_CONFIG.
+type MetricsConfig struct {
+	Namespace  string            `json:"namespace"`
+	Dimensions map[string]string `json:"dimensions"`
+	Metrics    []MetricEntry     `json:"metrics"`
+	Alarms     []AlarmEntry      `json:"alarms,omitempty"`
+}
+
+// MetricEntry describes a single eval metric for CloudWatch.
+type MetricEntry struct {
+	EvalID     string `json:"eval_id"`
+	MetricName string `json:"metric_name"`
+	MetricType string `json:"metric_type"`
+	Unit       string `json:"unit"`
+}
+
+// AlarmEntry describes a CloudWatch alarm threshold for a metric.
+type AlarmEntry struct {
+	MetricName string   `json:"metric_name"`
+	Min        *float64 `json:"min,omitempty"`
+	Max        *float64 `json:"max,omitempty"`
+}
+
+// buildMetricsConfig iterates pack evals and builds a MetricsConfig for
+// evals that define a Metric. Returns nil if no evals have metrics.
+func buildMetricsConfig(pack *prompt.Pack) *MetricsConfig {
+	var metrics []MetricEntry
+	var alarms []AlarmEntry
+
+	for _, ev := range pack.Evals {
+		if ev.Metric == nil {
+			continue
+		}
+
+		evalID := ev.ID
+		entry := MetricEntry{
+			EvalID:     evalID,
+			MetricName: ev.Metric.Name,
+			MetricType: string(ev.Metric.Type),
+			Unit:       metricTypeToUnit(ev.Metric.Type),
+		}
+		metrics = append(metrics, entry)
+
+		if ev.Metric.Range != nil {
+			alarms = append(alarms, AlarmEntry{
+				MetricName: ev.Metric.Name,
+				Min:        ev.Metric.Range.Min,
+				Max:        ev.Metric.Range.Max,
+			})
+		}
+	}
+
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	dims := map[string]string{
+		"pack_id": pack.ID,
+	}
+	if adaptersdk.IsMultiAgent(pack) {
+		dims["agent"] = "multi"
+	}
+
+	return &MetricsConfig{
+		Namespace:  metricsNamespace,
+		Dimensions: dims,
+		Metrics:    metrics,
+		Alarms:     alarms,
+	}
+}
+
+// metricTypeToUnit maps a PromptKit MetricType to a CloudWatch unit string.
+func metricTypeToUnit(mt evals.MetricType) string {
+	switch mt {
+	case evals.MetricCounter:
+		return unitCount
+	case evals.MetricHistogram:
+		return unitMilliseconds
+	case evals.MetricGauge, evals.MetricBoolean:
+		return unitNone
+	default:
+		return unitNone
+	}
+}

--- a/internal/agentcore/metrics_test.go
+++ b/internal/agentcore/metrics_test.go
@@ -1,0 +1,279 @@
+package agentcore
+
+import (
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/evals"
+	"github.com/AltairaLabs/PromptKit/runtime/prompt"
+)
+
+func floatPtr(f float64) *float64 { return &f }
+
+func TestBuildMetricsConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		pack       *prompt.Pack
+		wantNil    bool
+		wantCount  int // expected number of MetricEntry items
+		wantAlarms int // expected number of AlarmEntry items
+		wantDims   map[string]string
+		checkFunc  func(t *testing.T, mc *MetricsConfig)
+	}{
+		{
+			name: "gauge metric produces correct entry",
+			pack: &prompt.Pack{
+				ID: "test-pack",
+				Evals: []evals.EvalDef{
+					{
+						ID: "accuracy",
+						Metric: &evals.MetricDef{
+							Name: "accuracy_score",
+							Type: evals.MetricGauge,
+						},
+					},
+				},
+			},
+			wantCount:  1,
+			wantAlarms: 0,
+			wantDims:   map[string]string{"pack_id": "test-pack"},
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				m := mc.Metrics[0]
+				assertStr(t, "EvalID", m.EvalID, "accuracy")
+				assertStr(t, "MetricName", m.MetricName, "accuracy_score")
+				assertStr(t, "MetricType", m.MetricType, "gauge")
+				assertStr(t, "Unit", m.Unit, unitNone)
+			},
+		},
+		{
+			name: "counter with range produces alarm",
+			pack: &prompt.Pack{
+				ID: "test-pack",
+				Evals: []evals.EvalDef{
+					{
+						ID: "retries",
+						Metric: &evals.MetricDef{
+							Name: "retry_count",
+							Type: evals.MetricCounter,
+							Range: &evals.Range{
+								Min: floatPtr(0),
+								Max: floatPtr(10),
+							},
+						},
+					},
+				},
+			},
+			wantCount:  1,
+			wantAlarms: 1,
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				assertStr(t, "Unit", mc.Metrics[0].Unit, unitCount)
+				a := mc.Alarms[0]
+				assertStr(t, "AlarmMetricName", a.MetricName, "retry_count")
+				if a.Min == nil || *a.Min != 0 {
+					t.Errorf("alarm Min = %v, want 0", a.Min)
+				}
+				if a.Max == nil || *a.Max != 10 {
+					t.Errorf("alarm Max = %v, want 10", a.Max)
+				}
+			},
+		},
+		{
+			name: "no evals with metrics returns nil",
+			pack: &prompt.Pack{
+				ID: "test-pack",
+				Evals: []evals.EvalDef{
+					{ID: "no-metric"},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name:    "empty evals returns nil",
+			pack:    &prompt.Pack{ID: "test-pack"},
+			wantNil: true,
+		},
+		{
+			name: "multi-agent pack includes agent dimension",
+			pack: &prompt.Pack{
+				ID: "multi-pack",
+				Agents: &prompt.AgentsConfig{
+					Entry:   "coordinator",
+					Members: map[string]*prompt.AgentDef{"coordinator": {}, "worker": {}},
+				},
+				Evals: []evals.EvalDef{
+					{
+						ID:     "latency",
+						Metric: &evals.MetricDef{Name: "p99_latency", Type: evals.MetricHistogram},
+					},
+				},
+			},
+			wantCount: 1,
+			wantDims:  map[string]string{"pack_id": "multi-pack", "agent": "multi"},
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				assertStr(t, "Unit", mc.Metrics[0].Unit, unitMilliseconds)
+			},
+		},
+		{
+			name: "mixed evals only includes those with metrics",
+			pack: &prompt.Pack{
+				ID: "mixed-pack",
+				Evals: []evals.EvalDef{
+					{ID: "eval-no-metric"},
+					{
+						ID:     "eval-with-metric",
+						Metric: &evals.MetricDef{Name: "score", Type: evals.MetricBoolean},
+					},
+					{ID: "another-no-metric"},
+				},
+			},
+			wantCount: 1,
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				assertStr(t, "EvalID", mc.Metrics[0].EvalID, "eval-with-metric")
+				assertStr(t, "Unit", mc.Metrics[0].Unit, unitNone)
+			},
+		},
+		{
+			name: "all four metric types map to correct units",
+			pack: &prompt.Pack{
+				ID: "unit-pack",
+				Evals: []evals.EvalDef{
+					{ID: "e1", Metric: &evals.MetricDef{Name: "m1", Type: evals.MetricGauge}},
+					{ID: "e2", Metric: &evals.MetricDef{Name: "m2", Type: evals.MetricCounter}},
+					{ID: "e3", Metric: &evals.MetricDef{Name: "m3", Type: evals.MetricHistogram}},
+					{ID: "e4", Metric: &evals.MetricDef{Name: "m4", Type: evals.MetricBoolean}},
+				},
+			},
+			wantCount: 4,
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				wantUnits := []string{unitNone, unitCount, unitMilliseconds, unitNone}
+				for i, want := range wantUnits {
+					assertStr(t, mc.Metrics[i].MetricName, mc.Metrics[i].Unit, want)
+				}
+			},
+		},
+		{
+			name: "alarm with only min",
+			pack: &prompt.Pack{
+				ID: "min-pack",
+				Evals: []evals.EvalDef{
+					{
+						ID: "e1",
+						Metric: &evals.MetricDef{
+							Name:  "score",
+							Type:  evals.MetricGauge,
+							Range: &evals.Range{Min: floatPtr(0.5)},
+						},
+					},
+				},
+			},
+			wantAlarms: 1,
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				a := mc.Alarms[0]
+				if a.Min == nil || *a.Min != 0.5 {
+					t.Errorf("alarm Min = %v, want 0.5", a.Min)
+				}
+				if a.Max != nil {
+					t.Errorf("alarm Max = %v, want nil", a.Max)
+				}
+			},
+		},
+		{
+			name: "alarm with only max",
+			pack: &prompt.Pack{
+				ID: "max-pack",
+				Evals: []evals.EvalDef{
+					{
+						ID: "e1",
+						Metric: &evals.MetricDef{
+							Name:  "errors",
+							Type:  evals.MetricCounter,
+							Range: &evals.Range{Max: floatPtr(100)},
+						},
+					},
+				},
+			},
+			wantAlarms: 1,
+			checkFunc: func(t *testing.T, mc *MetricsConfig) {
+				t.Helper()
+				a := mc.Alarms[0]
+				if a.Min != nil {
+					t.Errorf("alarm Min = %v, want nil", a.Min)
+				}
+				if a.Max == nil || *a.Max != 100 {
+					t.Errorf("alarm Max = %v, want 100", a.Max)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := buildMetricsConfig(tt.pack)
+
+			if tt.wantNil {
+				if mc != nil {
+					t.Fatalf("expected nil, got %+v", mc)
+				}
+				return
+			}
+			if mc == nil {
+				t.Fatal("expected non-nil MetricsConfig")
+			}
+
+			assertStr(t, "Namespace", mc.Namespace, metricsNamespace)
+
+			if tt.wantCount > 0 && len(mc.Metrics) != tt.wantCount {
+				t.Fatalf("got %d metrics, want %d", len(mc.Metrics), tt.wantCount)
+			}
+			if tt.wantAlarms > 0 && len(mc.Alarms) != tt.wantAlarms {
+				t.Fatalf("got %d alarms, want %d", len(mc.Alarms), tt.wantAlarms)
+			}
+			if tt.wantDims != nil {
+				for k, want := range tt.wantDims {
+					got, ok := mc.Dimensions[k]
+					if !ok {
+						t.Errorf("missing dimension %q", k)
+					} else if got != want {
+						t.Errorf("dimension %q = %q, want %q", k, got, want)
+					}
+				}
+			}
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, mc)
+			}
+		})
+	}
+}
+
+func TestMetricTypeToUnit(t *testing.T) {
+	tests := []struct {
+		mt   evals.MetricType
+		want string
+	}{
+		{evals.MetricGauge, unitNone},
+		{evals.MetricCounter, unitCount},
+		{evals.MetricHistogram, unitMilliseconds},
+		{evals.MetricBoolean, unitNone},
+		{evals.MetricType("unknown"), unitNone},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.mt), func(t *testing.T) {
+			got := metricTypeToUnit(tt.mt)
+			if got != tt.want {
+				t.Errorf("metricTypeToUnit(%q) = %q, want %q", tt.mt, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertStr(t *testing.T, field, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %q, want %q", field, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Generate a `MetricsConfig` JSON blob from pack evals that define a `MetricDef`, mapping metric types (gauge, counter, histogram, boolean) to CloudWatch units
- Inject the config into runtimes via `PROMPTPACK_METRICS_CONFIG` env var so the PromptKit runtime container can publish eval metrics to CloudWatch
- Generate alarm entries from `Range` thresholds (min/max) on metrics
- Include `agent: "multi"` dimension for multi-agent packs

## Changes

| File | Change |
|------|--------|
| `metrics.go` (new) | `MetricsConfig`, `MetricEntry`, `AlarmEntry` types; `buildMetricsConfig`; `metricTypeToUnit` |
| `metrics_test.go` (new) | 8 table-driven tests + unit mapping tests |
| `envvars.go` | `EnvMetricsConfig` constant + `injectMetricsConfig` function |
| `envvars_test.go` | 3 tests for metrics injection |
| `apply.go` | Wire `injectMetricsConfig` into `prepareApply` |

## Test plan

- [x] Table-driven tests for all four metric types with correct unit mapping
- [x] Alarm generation with min-only, max-only, and both thresholds
- [x] Nil/empty config when no evals have metrics
- [x] Multi-agent packs include `agent` dimension
- [x] Mixed evals (some with metrics, some without)
- [x] `injectMetricsConfig` sets env var correctly and no-ops for empty evals
- [x] All 25 linters pass, tests pass with race detector