### PR TITLE
fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Checkout PromptKit (sibling)
       run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -44,7 +44,7 @@ jobs:
       run: GOWORK=off go test ./... -v -race -count=1 -coverprofile=coverage.out
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: coverage
         path: coverage.out
@@ -57,18 +57,18 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Checkout PromptKit (sibling)
       run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.1'
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
       with:
         version: v2.6.0
       env:
@@ -82,17 +82,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Download coverage artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: coverage
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5
+      uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
       run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.1'
 
@@ -31,7 +31,7 @@ jobs:
       run: go test ./... -v -race -count=1
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.25.1'
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to full commit SHAs instead of mutable tags
- Prevents supply chain attacks via tag mutation (e.g., attacker force-pushes a compromised version to `v4`)
- Resolves SonarCloud security hotspots

## Actions pinned

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-go` | v5 | `40f1582b2485089dde7abd97c1529aa768e1baff` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact` | v4 | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `golangci/golangci-lint-action` | v7 | `9fae48acfc02a90574d7c304a1758ef9895495fa` |
| `SonarSource/sonarqube-scan-action` | v5 | `2f77a1ec69fb1d595b06f35ab27e97605bdef703` |
| `goreleaser/goreleaser-action` | v6 | `e435ccd777264be153ace6237001ef4d979d3a7a` |

## Test plan

- [x] CI workflows still reference the same action versions (tag preserved in comment)
- [x] No functional change — just pinning to immutable refs