### PR TITLE
feat: use PromptKit image as default container with per-agent overrides

### DIFF
--- a/internal/agentcore/aws_client_real.go
+++ b/internal/agentcore/aws_client_real.go
@@ -64,20 +64,21 @@ func newRealCheckerFactory(ctx context.Context, cfg *Config) (resourceChecker, e
 func (c *realAWSClient) CreateRuntime(
 	ctx context.Context, name string, cfg *Config,
 ) (string, error) {
+	envVars := runtimeEnvVarsForAgent(cfg, name)
 	input := &bedrockagentcorecontrol.CreateAgentRuntimeInput{
 		AgentRuntimeName: aws.String(name),
 		RoleArn:          aws.String(cfg.RuntimeRoleARN),
 		AgentRuntimeArtifact: &types.AgentRuntimeArtifactMemberContainerConfiguration{
 			Value: types.ContainerConfiguration{
-				ContainerUri: aws.String("public.ecr.aws/bedrock-agentcore/runtime:latest"),
+				ContainerUri: aws.String(cfg.containerImageForAgent(name)),
 			},
 		},
 		NetworkConfiguration: &types.NetworkConfiguration{
 			NetworkMode: types.NetworkModePublic,
 		},
 	}
-	if len(cfg.RuntimeEnvVars) > 0 {
-		input.EnvironmentVariables = cfg.RuntimeEnvVars
+	if len(envVars) > 0 {
+		input.EnvironmentVariables = envVars
 	}
 	if authCfg := buildAuthorizerConfig(cfg); authCfg != nil {
 		input.AuthorizerConfiguration = authCfg
@@ -108,20 +109,21 @@ func (c *realAWSClient) UpdateRuntime(
 		return "", fmt.Errorf("UpdateAgentRuntime %q: could not extract ID from ARN %q", name, arn)
 	}
 
+	envVars := runtimeEnvVarsForAgent(cfg, name)
 	input := &bedrockagentcorecontrol.UpdateAgentRuntimeInput{
 		AgentRuntimeId: aws.String(id),
 		RoleArn:        aws.String(cfg.RuntimeRoleARN),
 		AgentRuntimeArtifact: &types.AgentRuntimeArtifactMemberContainerConfiguration{
 			Value: types.ContainerConfiguration{
-				ContainerUri: aws.String("public.ecr.aws/bedrock-agentcore/runtime:latest"),
+				ContainerUri: aws.String(cfg.containerImageForAgent(name)),
 			},
 		},
 		NetworkConfiguration: &types.NetworkConfiguration{
 			NetworkMode: types.NetworkModePublic,
 		},
 	}
-	if len(cfg.RuntimeEnvVars) > 0 {
-		input.EnvironmentVariables = cfg.RuntimeEnvVars
+	if len(envVars) > 0 {
+		input.EnvironmentVariables = envVars
 	}
 	if authCfg := buildAuthorizerConfig(cfg); authCfg != nil {
 		input.AuthorizerConfiguration = authCfg

--- a/internal/agentcore/config_test.go
+++ b/internal/agentcore/config_test.go
@@ -347,3 +347,158 @@ func TestValidate_WithInvalidTags(t *testing.T) {
 		t.Errorf("expected 1 error, got %d: %v", len(errs), errs)
 	}
 }
+
+func TestContainerImageForAgent(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Config
+		agentName string
+		want      string
+	}{
+		{
+			name:      "default when nothing set",
+			cfg:       Config{},
+			agentName: "worker",
+			want:      DefaultContainerImage,
+		},
+		{
+			name: "global container_image",
+			cfg: Config{
+				ContainerImage: "my-registry.io/custom:v1",
+			},
+			agentName: "worker",
+			want:      "my-registry.io/custom:v1",
+		},
+		{
+			name: "per-agent override",
+			cfg: Config{
+				ContainerImage: "my-registry.io/custom:v1",
+				AgentOverrides: map[string]*AgentOverride{
+					"worker": {ContainerImage: "my-registry.io/worker:v2"},
+				},
+			},
+			agentName: "worker",
+			want:      "my-registry.io/worker:v2",
+		},
+		{
+			name: "per-agent override takes precedence over global",
+			cfg: Config{
+				ContainerImage: "my-registry.io/global:v1",
+				AgentOverrides: map[string]*AgentOverride{
+					"agent-a": {ContainerImage: "my-registry.io/agent-a:v3"},
+				},
+			},
+			agentName: "agent-a",
+			want:      "my-registry.io/agent-a:v3",
+		},
+		{
+			name: "agent not in overrides falls back to global",
+			cfg: Config{
+				ContainerImage: "my-registry.io/global:v1",
+				AgentOverrides: map[string]*AgentOverride{
+					"other": {ContainerImage: "my-registry.io/other:v2"},
+				},
+			},
+			agentName: "worker",
+			want:      "my-registry.io/global:v1",
+		},
+		{
+			name: "override with empty image falls back to global",
+			cfg: Config{
+				ContainerImage: "my-registry.io/global:v1",
+				AgentOverrides: map[string]*AgentOverride{
+					"worker": {ContainerImage: ""},
+				},
+			},
+			agentName: "worker",
+			want:      "my-registry.io/global:v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.containerImageForAgent(tt.agentName)
+			if got != tt.want {
+				t.Errorf("containerImageForAgent(%q) = %q, want %q", tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateContainerImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		wantErrs int
+	}{
+		{name: "empty is valid", image: "", wantErrs: 0},
+		{name: "valid image", image: "ghcr.io/org/image:latest", wantErrs: 0},
+		{name: "no slash", image: "justanimage", wantErrs: 1},
+		{name: "whitespace", image: "my-registry.io/image name", wantErrs: 1},
+		{name: "tab", image: "my-registry.io/image\tname", wantErrs: 1},
+		{name: "no slash and whitespace", image: "bad image", wantErrs: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateContainerImage(tt.image)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("got %d errors %v, want %d", len(errs), errs, tt.wantErrs)
+			}
+		})
+	}
+}
+
+func TestValidate_ContainerImageIntegration(t *testing.T) {
+	cfg := Config{
+		Region:         "us-west-2",
+		RuntimeRoleARN: "arn:aws:iam::123456789012:role/test",
+		ContainerImage: "badimage",
+	}
+	errs := cfg.validate()
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for bad container_image, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidate_AgentOverrideContainerImage(t *testing.T) {
+	cfg := Config{
+		Region:         "us-west-2",
+		RuntimeRoleARN: "arn:aws:iam::123456789012:role/test",
+		AgentOverrides: map[string]*AgentOverride{
+			"worker": {ContainerImage: "noslash"},
+		},
+	}
+	errs := cfg.validate()
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for bad agent override image, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestParseConfig_ContainerImageAndOverrides(t *testing.T) {
+	raw := `{
+		"region": "us-west-2",
+		"runtime_role_arn": "arn:aws:iam::123456789012:role/test",
+		"container_image": "my-registry.io/custom:v1",
+		"agent_overrides": {
+			"worker": {"container_image": "my-registry.io/worker:v2"}
+		}
+	}`
+	cfg, err := parseConfig(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ContainerImage != "my-registry.io/custom:v1" {
+		t.Errorf("container_image = %q, want my-registry.io/custom:v1", cfg.ContainerImage)
+	}
+	if cfg.AgentOverrides == nil {
+		t.Fatal("expected agent_overrides to be parsed")
+	}
+	if cfg.AgentOverrides["worker"] == nil {
+		t.Fatal("expected agent_overrides[worker] to be parsed")
+	}
+	if cfg.AgentOverrides["worker"].ContainerImage != "my-registry.io/worker:v2" {
+		t.Errorf("agent_overrides[worker].container_image = %q, want my-registry.io/worker:v2",
+			cfg.AgentOverrides["worker"].ContainerImage)
+	}
+}

--- a/internal/agentcore/envvars.go
+++ b/internal/agentcore/envvars.go
@@ -19,7 +19,13 @@ const (
 	EnvPolicyEngineARN = "PROMPTPACK_POLICY_ENGINE_ARN"
 	EnvMetricsConfig   = "PROMPTPACK_METRICS_CONFIG"
 	EnvDashboardConfig = "PROMPTPACK_DASHBOARD_CONFIG"
+	EnvPackFile        = "PROMPTPACK_FILE"
+	EnvAgentName       = "PROMPTPACK_AGENT"
 )
+
+// defaultPackPath is the default path where the pack file is mounted
+// inside the container.
+const defaultPackPath = "/app/pack.json"
 
 // buildRuntimeEnvVars constructs the environment variable map that will be
 // passed to CreateAgentRuntime / UpdateAgentRuntime. It reads observability,
@@ -47,6 +53,20 @@ func buildRuntimeEnvVars(cfg *Config) map[string]string {
 		}
 	}
 
+	env[EnvPackFile] = defaultPackPath
+
+	return env
+}
+
+// runtimeEnvVarsForAgent returns a copy of cfg.RuntimeEnvVars with
+// PROMPTPACK_AGENT set to the given agent name. Each runtime gets its
+// own copy so the per-agent value does not leak across runtimes.
+func runtimeEnvVarsForAgent(cfg *Config, agentName string) map[string]string {
+	env := make(map[string]string, len(cfg.RuntimeEnvVars)+1)
+	for k, v := range cfg.RuntimeEnvVars {
+		env[k] = v
+	}
+	env[EnvAgentName] = agentName
 	return env
 }
 

--- a/internal/agentcore/provider.go
+++ b/internal/agentcore/provider.go
@@ -73,6 +73,23 @@ const configSchema = `{
           "description": "Allowed JWT client IDs"
         }
       }
+    },
+    "container_image": {
+      "type": "string",
+      "description": "Container image URI for agent runtimes (default: ghcr.io/altairalabs/promptkit-agentcore:latest)"
+    },
+    "agent_overrides": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "container_image": {
+            "type": "string",
+            "description": "Container image URI override for this agent"
+          }
+        }
+      },
+      "description": "Per-agent configuration overrides keyed by agent name"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary

Closes #6.

- Replace hardcoded `public.ecr.aws/bedrock-agentcore/runtime:latest` with configurable `container_image` field (default: `ghcr.io/altairalabs/promptkit-agentcore:latest`)
- Support per-agent image overrides via `agent_overrides` map (precedence: agent override > global > default)
- Inject `PROMPTPACK_FILE` and `PROMPTPACK_AGENT` env vars into each runtime container

## Test plan

- [x] `containerImageForAgent` table-driven tests (6 cases: default, global, per-agent, precedence, fallback, empty override)
- [x] `validateContainerImage` tests (empty, valid, no slash, whitespace, combined)
- [x] `runtimeEnvVarsForAgent` tests (agent name injection, no mutation, different agents)
- [x] All existing tests updated for `PROMPTPACK_FILE` in env vars
- [x] `golangci-lint run` passes (0 issues)
- [x] `go test ./... -race` passes
- [x] Both binaries build successfully