### PR TITLE
feat: add Dockerfile and CI workflow for agentcore-runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+agentcore-runtime
+promptarena-deploy-agentcore
+go.work
+go.work.sum
+*.out
+coverage.*
+docs/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. 1.0.0)'
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+    - name: Log in to ghcr.io
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+      with:
+        images: ghcr.io/altairalabs/promptkit-agentcore
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Determine version
+      id: version
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+        elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        else
+          echo "version=dev" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198571cfb76f00 # v6.18.0
+      with:
+        context: .
+        file: Dockerfile.agentcore
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          VERSION=${{ steps.version.outputs.version }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile.agentcore
+++ b/Dockerfile.agentcore
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.25-bookworm AS builder
+
+ARG VERSION=dev
+
+WORKDIR /build
+
+# Clone PromptKit sibling (needed for replace directives in go.mod)
+RUN git clone --depth 1 https://github.com/AltairaLabs/PromptKit.git /build/promptkit
+
+# Copy module files first for layer caching
+COPY go.mod go.sum ./
+
+# Rewrite replace directives to point to /build/promptkit
+RUN sed -i 's|=> ../promptkit/|=> /build/promptkit/|g' go.mod
+
+RUN go mod download
+
+# Copy source (go.mod gets overwritten, so rewrite again)
+COPY . .
+RUN sed -i 's|=> ../promptkit/|=> /build/promptkit/|g' go.mod
+
+# Build static binary
+RUN CGO_ENABLED=0 GOWORK=off GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${VERSION}" \
+    -o /agentcore-runtime \
+    ./cmd/agentcore-runtime/
+
+# Runtime stage
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /agentcore-runtime /agentcore-runtime
+
+EXPOSE 9000
+
+ENTRYPOINT ["/agentcore-runtime"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test build build-runtime check install-hooks
+.PHONY: fmt lint test build build-runtime check install-hooks docker-build
 
 # Format code with goimports
 fmt:
@@ -22,6 +22,10 @@ build-runtime:
 
 # Run all quality checks (what pre-commit runs)
 check: fmt lint test build
+
+# Build Docker image locally
+docker-build:
+	docker build -f Dockerfile.agentcore -t promptkit-agentcore:local .
 
 # Install git hooks
 install-hooks:


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.agentcore` — multi-stage build producing a ~20 MB distroless image for `agentcore-runtime`
- Adds `.github/workflows/docker.yml` — builds and pushes to `ghcr.io/altairalabs/promptkit-agentcore` on `v*` tags and manual dispatch, multi-platform (linux/amd64, linux/arm64) with GHA build cache
- Adds `.dockerignore` to exclude unnecessary files from build context
- Adds `make docker-build` target for local development

Closes #5

## Test plan
- [x] Local `docker build` succeeds
- [x] Container exits with expected `PROMPTPACK_FILE is required` error when no pack file is mounted
- [x] Image size is ~20 MB (distroless base)
- [ ] Verify CI workflow triggers correctly on a `v*` tag push