### PR TITLE
feat: parse ArenaConfig in adapter (Phase 1 consumer side)

### DIFF
--- a/internal/agentcore/apply.go
+++ b/internal/agentcore/apply.go
@@ -72,6 +72,11 @@ func (p *Provider) prepareApply(
 		return nil, fmt.Errorf("agentcore: failed to parse deploy config: %w", err)
 	}
 
+	cfg.ArenaConfig, err = parseArenaConfig(req.ArenaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("agentcore: %w", err)
+	}
+
 	client, err := p.awsClientFunc(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("agentcore: failed to create AWS client: %w", err)
@@ -146,6 +151,11 @@ func (p *Provider) applyDryRun(
 	cfg, err := parseConfig(req.DeployConfig)
 	if err != nil {
 		return "", fmt.Errorf("agentcore: failed to parse deploy config: %w", err)
+	}
+
+	cfg.ArenaConfig, err = parseArenaConfig(req.ArenaConfig)
+	if err != nil {
+		return "", fmt.Errorf("agentcore: %w", err)
 	}
 
 	reporter := adaptersdk.NewProgressReporter(callback)

--- a/internal/agentcore/apply_test.go
+++ b/internal/agentcore/apply_test.go
@@ -243,6 +243,7 @@ func TestApply_SingleAgent_StreamsCorrectEvents(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -301,6 +302,7 @@ func TestApply_SingleAgentWithTools(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithTools(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -342,6 +344,7 @@ func TestApply_MultiAgent_DependencyOrder(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -419,6 +422,7 @@ func TestApply_MultiAgentWithEvals(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPackWithEvals(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -482,6 +486,7 @@ func TestApply_StateContainsAllResourceInfo(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, stateStr, err := collectEvents(t, provider, req)
@@ -541,6 +546,7 @@ func TestApply_PartialFailure_ReturnsStateForSuccessfulResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -600,6 +606,7 @@ func TestApply_ProgressMessages(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -652,6 +659,7 @@ func TestApply_BadPackJSON(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     `{not valid}`,
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -668,6 +676,7 @@ func TestApply_BadDeployConfig(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: `{not valid}`,
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -697,6 +706,7 @@ func TestApply_EmptyPack_CreatesRuntimeOnly(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     string(packJSON),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -737,6 +747,7 @@ func TestApply_AWSClientFactoryError(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -764,6 +775,7 @@ func TestApply_ToolFailure_ContinuesToRuntime(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithTools(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -821,6 +833,7 @@ func TestApply_RuntimeFailure(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, stateStr, err := collectEvents(t, provider, req)
@@ -845,6 +858,7 @@ func TestApply_CallbackError_AbortsEarly(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	callCount := 0
@@ -898,6 +912,7 @@ func TestApply_EvalWithEmptyID(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     string(packJSON),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -952,6 +967,7 @@ func TestApply_NonLLMEvals_Skipped(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     string(packJSON),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -982,6 +998,7 @@ func TestApply_EvalFailure(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPackWithEvals(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, stateStr, err := collectEvents(t, provider, req)
@@ -1006,6 +1023,7 @@ func TestApply_NoEvals_NoOnlineEvalConfig(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1037,6 +1055,7 @@ func TestApply_OnlineEvalConfigFailure_ContinuesApply(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPackWithEvals(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1094,6 +1113,7 @@ func TestApply_SingleAgent_Update(t *testing.T) {
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
 		PriorState:   priorStateWithRuntime("mypack", priorARN),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1166,6 +1186,7 @@ func TestApply_MixedCreateAndUpdate(t *testing.T) {
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
 		PriorState:   string(priorJSON),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1237,6 +1258,7 @@ func TestApply_UpdateRuntime_Failure(t *testing.T) {
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
 		PriorState:   priorStateWithRuntime("mypack", priorARN),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, stateStr, err := collectEvents(t, provider, req)
@@ -1266,6 +1288,7 @@ func TestApply_WithMemory_CreatesMemoryResource(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigWithMemory(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1341,6 +1364,7 @@ func TestApply_WithMemory_Failure(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigWithMemory(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, stateStr, err := collectEvents(t, provider, req)
@@ -1376,6 +1400,7 @@ func TestApply_WithoutMemory_NoMemoryResource(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1412,6 +1437,7 @@ func TestApply_MultiAgent_EntryAgentGetsEndpoints(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1513,6 +1539,7 @@ func TestApply_WithValidators_NoPolicyResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithValidators(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1533,6 +1560,7 @@ func TestApply_WithToolPolicy_CreatesPolicyResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithToolPolicy(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1557,6 +1585,7 @@ func TestApply_NoValidators_NoPolicyResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1589,6 +1618,7 @@ func TestApply_PolicyEngineFailure_ContinuesToRuntime(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithToolPolicy(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1655,6 +1685,7 @@ func TestApply_DryRun_SingleAgent_NoAWSCalls(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1711,6 +1742,7 @@ func TestApply_DryRun_WithTools_PlansAllResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithTools(),
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1753,6 +1785,7 @@ func TestApply_DryRun_MultiAgent_PlansAllResources(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     multiAgentPack(),
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1806,6 +1839,7 @@ func TestApply_DryRun_WithMemory_PlansMemoryResource(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: cfg,
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -1855,6 +1889,7 @@ func TestApply_DryRun_EmitsProgressEvents(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, _, err := collectEvents(t, provider, req)
@@ -1886,6 +1921,7 @@ func TestApply_DryRun_BadPackJSON(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     `{not valid}`,
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -1907,6 +1943,7 @@ func TestApply_DryRun_CallbackError_AbortsEarly(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigDryRun(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	callCount := 0
@@ -1932,6 +1969,7 @@ func TestApply_DryRunFalse_StillCallsAWS(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: `{"region":"us-west-2","runtime_role_arn":"arn:aws:iam::123456789012:role/test","container_image":"123456789012.dkr.ecr.us-west-2.amazonaws.com/promptkit-agentcore:latest","dry_run":false}`,
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	events, stateStr, err := collectEvents(t, provider, req)
@@ -2072,6 +2110,7 @@ func TestApply_SingleAgent_ResourceTagsIncludePackMetadata(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -2109,6 +2148,7 @@ func TestApply_SingleAgent_ResourceTagsIncludeUserTags(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfigWithTags(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -2150,6 +2190,7 @@ func TestApply_WithTools_TagsAppliedToGateway(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPackWithTools(),
 		DeployConfig: validConfigWithTags(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -2198,6 +2239,7 @@ func TestApply_WithMemory_TagsAppliedToMemory(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: cfgWithTags,
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -2234,6 +2276,7 @@ func TestApply_NoTags_ResourceTagsHaveDefaultsOnly(t *testing.T) {
 	req := &deploy.PlanRequest{
 		PackJSON:     singleAgentPack(),
 		DeployConfig: validConfig(),
+		ArenaConfig:  validArenaConfigJSON,
 	}
 
 	_, _, err := collectEvents(t, provider, req)
@@ -2255,5 +2298,59 @@ func TestApply_NoTags_ResourceTagsHaveDefaultsOnly(t *testing.T) {
 	}
 	if tags[TagKeyVersion] != "v1.0.0" {
 		t.Errorf("version = %q, want v1.0.0", tags[TagKeyVersion])
+	}
+}
+
+func TestApply_MissingArenaConfig(t *testing.T) {
+	provider := newSimulatedProvider()
+	req := &deploy.PlanRequest{
+		PackJSON:     singleAgentPack(),
+		DeployConfig: validConfig(),
+	}
+
+	_, _, err := collectEvents(t, provider, req)
+	if err == nil {
+		t.Fatal("expected error for missing arena config")
+	}
+	if !strings.Contains(err.Error(), "arena_config is required") {
+		t.Errorf("error = %q, want 'arena_config is required'", err.Error())
+	}
+}
+
+func TestApply_InvalidArenaConfig(t *testing.T) {
+	provider := newSimulatedProvider()
+	req := &deploy.PlanRequest{
+		PackJSON:     singleAgentPack(),
+		DeployConfig: validConfig(),
+		ArenaConfig:  `{bad json`,
+	}
+
+	_, _, err := collectEvents(t, provider, req)
+	if err == nil {
+		t.Fatal("expected error for invalid arena config JSON")
+	}
+	if !strings.Contains(err.Error(), "invalid arena_config JSON") {
+		t.Errorf("error = %q, want 'invalid arena_config JSON'", err.Error())
+	}
+}
+
+func TestApply_DryRun_MissingArenaConfig(t *testing.T) {
+	provider := &Provider{
+		awsClientFunc: func(_ context.Context, _ *Config) (awsClient, error) {
+			panic("dry-run should not create AWS client")
+		},
+	}
+
+	req := &deploy.PlanRequest{
+		PackJSON:     singleAgentPack(),
+		DeployConfig: validConfigDryRun(),
+	}
+
+	_, _, err := collectEvents(t, provider, req)
+	if err == nil {
+		t.Fatal("expected error for missing arena config in dry-run")
+	}
+	if !strings.Contains(err.Error(), "arena_config is required") {
+		t.Errorf("error = %q, want 'arena_config is required'", err.Error())
 	}
 }

--- a/internal/agentcore/arena_config.go
+++ b/internal/agentcore/arena_config.go
@@ -1,0 +1,47 @@
+package agentcore
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ArenaConfig holds the subset of the PromptKit arena config that the
+// adapter needs for infrastructure decisions.
+type ArenaConfig struct {
+	ToolSpecs  map[string]*ArenaToolSpec `json:"tool_specs,omitempty"`
+	MCPServers []ArenaMCPServer          `json:"mcp_servers,omitempty"`
+}
+
+// ArenaToolSpec describes a single tool from the arena config.
+type ArenaToolSpec struct {
+	Name        string           `json:"name,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Mode        string           `json:"mode,omitempty"` // "mock" | "live" | "mcp" | "a2a"
+	InputSchema any              `json:"input_schema,omitempty"`
+	HTTPConfig  *ArenaHTTPConfig `json:"http,omitempty"`
+}
+
+// ArenaHTTPConfig holds HTTP-specific tool configuration.
+type ArenaHTTPConfig struct {
+	URL    string `json:"url,omitempty"`
+	Method string `json:"method,omitempty"`
+}
+
+// ArenaMCPServer describes an MCP server from the arena config.
+type ArenaMCPServer struct {
+	Name    string   `json:"name,omitempty"`
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+}
+
+// parseArenaConfig deserializes the arena config JSON string.
+func parseArenaConfig(raw string) (*ArenaConfig, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("arena_config is required")
+	}
+	var cfg ArenaConfig
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return nil, fmt.Errorf("invalid arena_config JSON: %w", err)
+	}
+	return &cfg, nil
+}

--- a/internal/agentcore/arena_config_test.go
+++ b/internal/agentcore/arena_config_test.go
@@ -1,0 +1,167 @@
+package agentcore
+
+import (
+	"testing"
+)
+
+func TestParseArenaConfig_Empty(t *testing.T) {
+	_, err := parseArenaConfig("")
+	if err == nil {
+		t.Fatal("expected error for empty string")
+	}
+	if got := err.Error(); got != "arena_config is required" {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestParseArenaConfig_InvalidJSON(t *testing.T) {
+	_, err := parseArenaConfig("{not-json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if got := err.Error(); got == "arena_config is required" {
+		t.Fatal("got wrong error — should be a JSON parse error")
+	}
+}
+
+func TestParseArenaConfig_MinimalValid(t *testing.T) {
+	cfg, err := parseArenaConfig("{}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestParseArenaConfig_WithToolSpecs(t *testing.T) {
+	raw := `{
+		"tool_specs": {
+			"search": {
+				"name": "search",
+				"description": "Web search",
+				"mode": "live",
+				"http": {
+					"url": "https://api.example.com/search",
+					"method": "POST"
+				}
+			},
+			"calculator": {
+				"name": "calculator",
+				"mode": "mock"
+			}
+		}
+	}`
+	cfg, err := parseArenaConfig(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.ToolSpecs) != 2 {
+		t.Fatalf("expected 2 tool specs, got %d", len(cfg.ToolSpecs))
+	}
+
+	search := cfg.ToolSpecs["search"]
+	if search.Name != "search" {
+		t.Errorf("expected name 'search', got %q", search.Name)
+	}
+	if search.Mode != "live" {
+		t.Errorf("expected mode 'live', got %q", search.Mode)
+	}
+	if search.HTTPConfig == nil {
+		t.Fatal("expected non-nil HTTPConfig")
+	}
+	if search.HTTPConfig.URL != "https://api.example.com/search" {
+		t.Errorf("unexpected URL: %s", search.HTTPConfig.URL)
+	}
+
+	calc := cfg.ToolSpecs["calculator"]
+	if calc.Mode != "mock" {
+		t.Errorf("expected mode 'mock', got %q", calc.Mode)
+	}
+	if calc.HTTPConfig != nil {
+		t.Error("expected nil HTTPConfig for calculator")
+	}
+}
+
+func TestParseArenaConfig_WithMCPServers(t *testing.T) {
+	raw := `{
+		"mcp_servers": [
+			{
+				"name": "my-server",
+				"command": "npx",
+				"args": ["-y", "@example/mcp-server"]
+			}
+		]
+	}`
+	cfg, err := parseArenaConfig(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.MCPServers) != 1 {
+		t.Fatalf("expected 1 MCP server, got %d", len(cfg.MCPServers))
+	}
+	srv := cfg.MCPServers[0]
+	if srv.Name != "my-server" {
+		t.Errorf("expected name 'my-server', got %q", srv.Name)
+	}
+	if srv.Command != "npx" {
+		t.Errorf("expected command 'npx', got %q", srv.Command)
+	}
+	if len(srv.Args) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(srv.Args))
+	}
+}
+
+// toolSpecForName returns the tool spec with the given name, or nil if
+// not found. Defined in test file until production code needs it.
+func (a *ArenaConfig) toolSpecForName(name string) *ArenaToolSpec {
+	if a == nil || a.ToolSpecs == nil {
+		return nil
+	}
+	return a.ToolSpecs[name]
+}
+
+func TestArenaConfig_ToolSpecForName(t *testing.T) {
+	cfg := &ArenaConfig{
+		ToolSpecs: map[string]*ArenaToolSpec{
+			"search": {Name: "search", Mode: "live"},
+		},
+	}
+
+	got := cfg.toolSpecForName("search")
+	if got == nil {
+		t.Fatal("expected non-nil tool spec")
+	}
+	if got.Mode != "live" {
+		t.Errorf("expected mode 'live', got %q", got.Mode)
+	}
+
+	if cfg.toolSpecForName("missing") != nil {
+		t.Error("expected nil for missing tool")
+	}
+}
+
+func TestArenaConfig_ToolSpecForName_NilReceiver(t *testing.T) {
+	var cfg *ArenaConfig
+	if cfg.toolSpecForName("anything") != nil {
+		t.Error("expected nil from nil receiver")
+	}
+}
+
+func TestArenaConfig_ToolSpecForName_NilToolSpecs(t *testing.T) {
+	cfg := &ArenaConfig{}
+	if cfg.toolSpecForName("anything") != nil {
+		t.Error("expected nil when ToolSpecs is nil")
+	}
+}
+
+func TestParseArenaConfig_UnknownFieldsIgnored(t *testing.T) {
+	raw := `{"unknown_field": "value", "tool_specs": {}}`
+	cfg, err := parseArenaConfig(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}

--- a/internal/agentcore/config.go
+++ b/internal/agentcore/config.go
@@ -50,6 +50,10 @@ type Config struct {
 	// GatewayARN is populated at apply-time after the tool gateway phase.
 	// Used by Cedar tool policies that need a specific gateway resource. NOT serialized.
 	GatewayARN string `json:"-"`
+
+	// ArenaConfig is the parsed arena configuration, populated from
+	// PlanRequest.ArenaConfig. NOT part of the deploy config JSON.
+	ArenaConfig *ArenaConfig `json:"-"`
 }
 
 // AgentOverride holds per-agent configuration overrides.

--- a/internal/agentcore/plan.go
+++ b/internal/agentcore/plan.go
@@ -28,7 +28,13 @@ func (p *Provider) Plan(_ context.Context, req *deploy.PlanRequest) (*deploy.Pla
 		return nil, fmt.Errorf("agentcore: config validation failed: %s", errs[0])
 	}
 
-	// 3. Parse prior state (if any).
+	// 3. Parse the arena config.
+	cfg.ArenaConfig, err = parseArenaConfig(req.ArenaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("agentcore: %w", err)
+	}
+
+	// 4. Parse prior state (if any).
 	var prior *AdapterState
 	if req.PriorState != "" {
 		prior = &AdapterState{}
@@ -37,13 +43,13 @@ func (p *Provider) Plan(_ context.Context, req *deploy.PlanRequest) (*deploy.Pla
 		}
 	}
 
-	// 4. Generate desired resources.
+	// 5. Generate desired resources.
 	desired := generateDesiredResources(pack, cfg)
 
-	// 5. Diff against prior state.
+	// 6. Diff against prior state.
 	changes := diffResources(desired, prior)
 
-	// 6. Build summary.
+	// 7. Build summary.
 	summary := buildSummary(changes)
 
 	return &deploy.PlanResponse{

--- a/internal/agentcore/provider_test.go
+++ b/internal/agentcore/provider_test.go
@@ -158,6 +158,7 @@ func TestPlanViaJSONRPC(t *testing.T) {
 	params := map[string]string{
 		"pack_json":     `{"id":"mypack","version":"v1.0.0"}`,
 		"deploy_config": `{"region":"us-west-2","runtime_role_arn":"arn:aws:iam::123456789012:role/test","container_image":"123456789012.dkr.ecr.us-west-2.amazonaws.com/promptkit-agentcore:latest"}`,
+		"arena_config":  `{"tool_specs":{}}`,
 	}
 	resp := callAdapter(t, jsonRPCRequest("plan", 5, params))
 


### PR DESCRIPTION
## Summary
- Define lightweight `ArenaConfig`, `ArenaToolSpec`, `ArenaHTTPConfig`, `ArenaMCPServer` types that mirror the subset of `config.Config` the adapter needs
- Add `parseArenaConfig` helper with validation (required field, valid JSON)
- Wire parsing into `Plan()`, `prepareApply()`, and `applyDryRun()` — missing/invalid ArenaConfig now returns an error
- Add `ArenaConfig *ArenaConfig` transient field (`json:"-"`) to `Config` struct

This is the foundation for later phases that will use the parsed arena config for tool target decisions, Cedar schema input, etc.

## Test plan
- [x] Unit tests for `parseArenaConfig` (empty, invalid JSON, valid with tool specs, MCP servers, unknown fields ignored)
- [x] Unit tests for `toolSpecForName` helper (found, missing, nil receiver, nil map)
- [x] All 57 existing Plan/Apply tests updated with valid `ArenaConfig` field
- [x] New error tests: `TestPlan_MissingArenaConfig`, `TestPlan_InvalidArenaConfig`
- [x] New error tests: `TestApply_MissingArenaConfig`, `TestApply_InvalidArenaConfig`, `TestApply_DryRun_MissingArenaConfig`
- [x] JSON-RPC integration test updated (`TestPlanViaJSONRPC`)
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./... -race -count=1` — all pass
- [x] `go build` — compiles cleanly