### PR TITLE
feat: use ArenaConfig to configure gateway tool targets (Phase 2)

### DIFF
--- a/internal/agentcore/arena_config.go
+++ b/internal/agentcore/arena_config.go
@@ -34,6 +34,15 @@ type ArenaMCPServer struct {
 	Args    []string `json:"args,omitempty"`
 }
 
+// toolSpecForName returns the tool spec with the given name, or nil if
+// not found.
+func (a *ArenaConfig) toolSpecForName(name string) *ArenaToolSpec {
+	if a == nil || a.ToolSpecs == nil {
+		return nil
+	}
+	return a.ToolSpecs[name]
+}
+
 // parseArenaConfig deserializes the arena config JSON string.
 func parseArenaConfig(raw string) (*ArenaConfig, error) {
 	if raw == "" {

--- a/internal/agentcore/arena_config_test.go
+++ b/internal/agentcore/arena_config_test.go
@@ -112,15 +112,6 @@ func TestParseArenaConfig_WithMCPServers(t *testing.T) {
 	}
 }
 
-// toolSpecForName returns the tool spec with the given name, or nil if
-// not found. Defined in test file until production code needs it.
-func (a *ArenaConfig) toolSpecForName(name string) *ArenaToolSpec {
-	if a == nil || a.ToolSpecs == nil {
-		return nil
-	}
-	return a.ToolSpecs[name]
-}
-
 func TestArenaConfig_ToolSpecForName(t *testing.T) {
 	cfg := &ArenaConfig{
 		ToolSpecs: map[string]*ArenaToolSpec{

--- a/internal/agentcore/aws_client_real.go
+++ b/internal/agentcore/aws_client_real.go
@@ -285,15 +285,9 @@ func (c *realAWSClient) CreateGatewayTool(
 	}
 
 	targetOut, err := c.client.CreateGatewayTarget(ctx, &bedrockagentcorecontrol.CreateGatewayTargetInput{
-		GatewayIdentifier: aws.String(c.gatewayID),
-		Name:              aws.String(name),
-		TargetConfiguration: &types.TargetConfigurationMemberMcp{
-			Value: &types.McpTargetConfigurationMemberMcpServer{
-				Value: types.McpServerTargetConfiguration{
-					Endpoint: aws.String(fmt.Sprintf("https://%s.mcp.local", name)),
-				},
-			},
-		},
+		GatewayIdentifier:   aws.String(c.gatewayID),
+		Name:                aws.String(name),
+		TargetConfiguration: buildTargetConfig(name, cfg),
 	})
 	if err != nil {
 		if isConflictError(err) {

--- a/internal/agentcore/gateway.go
+++ b/internal/agentcore/gateway.go
@@ -1,0 +1,33 @@
+package agentcore
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+)
+
+// buildTargetConfig returns the SDK TargetConfiguration for a gateway tool.
+// It uses the ArenaConfig tool spec (if available) to determine the endpoint.
+// Falls back to a placeholder MCP endpoint if no spec or HTTP config is found.
+func buildTargetConfig(name string, cfg *Config) *types.TargetConfigurationMemberMcp {
+	spec := cfg.ArenaConfig.toolSpecForName(name)
+	endpoint := resolveToolEndpoint(name, spec)
+	return &types.TargetConfigurationMemberMcp{
+		Value: &types.McpTargetConfigurationMemberMcpServer{
+			Value: types.McpServerTargetConfiguration{
+				Endpoint: aws.String(endpoint),
+			},
+		},
+	}
+}
+
+// resolveToolEndpoint returns the endpoint URL for a gateway tool target.
+// If the tool spec has an HTTP URL, use that. Otherwise fall back to a
+// placeholder.
+func resolveToolEndpoint(name string, spec *ArenaToolSpec) string {
+	if spec != nil && spec.HTTPConfig != nil && spec.HTTPConfig.URL != "" {
+		return spec.HTTPConfig.URL
+	}
+	return fmt.Sprintf("https://%s.mcp.local", name)
+}

--- a/internal/agentcore/gateway_test.go
+++ b/internal/agentcore/gateway_test.go
@@ -1,0 +1,107 @@
+package agentcore
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol/types"
+)
+
+func TestResolveToolEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		spec     *ArenaToolSpec
+		want     string
+	}{
+		{
+			name:     "nil spec falls back to placeholder",
+			toolName: "search",
+			spec:     nil,
+			want:     "https://search.mcp.local",
+		},
+		{
+			name:     "spec with no HTTPConfig falls back to placeholder",
+			toolName: "calc",
+			spec:     &ArenaToolSpec{Mode: "mock"},
+			want:     "https://calc.mcp.local",
+		},
+		{
+			name:     "spec with empty URL falls back to placeholder",
+			toolName: "calc",
+			spec:     &ArenaToolSpec{HTTPConfig: &ArenaHTTPConfig{Method: "POST"}},
+			want:     "https://calc.mcp.local",
+		},
+		{
+			name:     "spec with HTTP URL uses real endpoint",
+			toolName: "search",
+			spec: &ArenaToolSpec{
+				HTTPConfig: &ArenaHTTPConfig{URL: "https://api.example.com/search"},
+			},
+			want: "https://api.example.com/search",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveToolEndpoint(tt.toolName, tt.spec)
+			if got != tt.want {
+				t.Errorf("resolveToolEndpoint(%q) = %q, want %q", tt.toolName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTargetConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		toolName     string
+		cfg          *Config
+		wantEndpoint string
+	}{
+		{
+			name:         "nil ArenaConfig falls back to placeholder",
+			toolName:     "search",
+			cfg:          &Config{},
+			wantEndpoint: "https://search.mcp.local",
+		},
+		{
+			name:     "no matching tool spec falls back to placeholder",
+			toolName: "unknown",
+			cfg: &Config{
+				ArenaConfig: &ArenaConfig{
+					ToolSpecs: map[string]*ArenaToolSpec{
+						"other": {HTTPConfig: &ArenaHTTPConfig{URL: "https://other.example.com"}},
+					},
+				},
+			},
+			wantEndpoint: "https://unknown.mcp.local",
+		},
+		{
+			name:     "matching tool spec with HTTP URL uses real endpoint",
+			toolName: "search",
+			cfg: &Config{
+				ArenaConfig: &ArenaConfig{
+					ToolSpecs: map[string]*ArenaToolSpec{
+						"search": {HTTPConfig: &ArenaHTTPConfig{URL: "https://api.example.com/search"}},
+					},
+				},
+			},
+			wantEndpoint: "https://api.example.com/search",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTargetConfig(tt.toolName, tt.cfg)
+
+			mcpTarget, ok := got.Value.(*types.McpTargetConfigurationMemberMcpServer)
+			if !ok {
+				t.Fatal("expected McpTargetConfigurationMemberMcpServer")
+			}
+			endpoint := *mcpTarget.Value.Endpoint
+			if endpoint != tt.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tt.wantEndpoint)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extract `buildTargetConfig` and `resolveToolEndpoint` helpers into new `gateway.go` file to configure gateway tool targets from ArenaConfig
- Move `toolSpecForName` from test-only code to production `arena_config.go` since it's now needed by the gateway helpers
- Replace hardcoded placeholder MCP endpoints in `CreateGatewayTool` with real endpoints from ArenaConfig tool specs (falls back to placeholder when no HTTP URL is configured)

## Test plan
- [x] Table-driven tests for `resolveToolEndpoint` (nil spec, no HTTP config, empty URL, real URL)
- [x] Table-driven tests for `buildTargetConfig` (nil ArenaConfig, missing tool spec, matching tool spec with HTTP URL)
- [x] Existing tests pass unchanged (simulated client is unaffected)
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./... -race` — all pass