### PR TITLE
feat: expand memory_store config to support all 5 AgentCore strategies (#38)

### DIFF
--- a/internal/agentcore/apply.go
+++ b/internal/agentcore/apply.go
@@ -316,7 +316,7 @@ func applyMemoryPreStep(
 	ctx context.Context, ac *applyContext,
 	resources []ResourceState, applyErr error,
 ) ([]ResourceState, error) {
-	if ac.cfg.MemoryStore == "" {
+	if !ac.cfg.HasMemory() {
 		return resources, applyErr
 	}
 	memRes, memErr := createMemoryResource(ctx, ac.reporter, ac.client, ac.cfg, ac.pack)

--- a/internal/agentcore/envvars.go
+++ b/internal/agentcore/envvars.go
@@ -42,8 +42,8 @@ func buildRuntimeEnvVars(cfg *Config) map[string]string {
 		}
 	}
 
-	if cfg.MemoryStore != "" {
-		env[EnvMemoryStore] = cfg.MemoryStore
+	if cfg.HasMemory() {
+		env[EnvMemoryStore] = cfg.MemoryStrategiesCSV()
 	}
 
 	if cfg.A2AAuth != nil && cfg.A2AAuth.Mode != "" {

--- a/internal/agentcore/envvars_test.go
+++ b/internal/agentcore/envvars_test.go
@@ -71,29 +71,29 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 			},
 		},
 		{
-			name: "memory store session",
+			name: "memory episodic strategy",
 			cfg: &Config{
-				MemoryStore: "session",
+				Memory: MemoryConfig{Strategies: []string{"episodic"}},
 			},
 			want: map[string]string{
-				EnvMemoryStore: "session",
+				EnvMemoryStore: "episodic",
 				EnvPackFile:    defaultPackPath,
 			},
 		},
 		{
-			name: "memory store persistent",
+			name: "memory semantic strategy",
 			cfg: &Config{
-				MemoryStore: "persistent",
+				Memory: MemoryConfig{Strategies: []string{"semantic"}},
 			},
 			want: map[string]string{
-				EnvMemoryStore: "persistent",
+				EnvMemoryStore: "semantic",
 				EnvPackFile:    defaultPackPath,
 			},
 		},
 		{
 			name: "combined observability and memory",
 			cfg: &Config{
-				MemoryStore: "session",
+				Memory: MemoryConfig{Strategies: []string{"episodic"}},
 				Observability: &ObservabilityConfig{
 					CloudWatchLogGroup: "/aws/logs",
 					TracingEnabled:     true,
@@ -102,7 +102,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 			want: map[string]string{
 				EnvLogGroup:       "/aws/logs",
 				EnvTracingEnabled: "true",
-				EnvMemoryStore:    "session",
+				EnvMemoryStore:    "episodic",
 				EnvPackFile:       defaultPackPath,
 			},
 		},
@@ -427,7 +427,7 @@ func TestRuntimeEnvVarsForAgent(t *testing.T) {
 		cfg := &Config{
 			RuntimeEnvVars: map[string]string{
 				EnvPackFile:    defaultPackPath,
-				EnvMemoryStore: "session",
+				EnvMemoryStore: "episodic",
 			},
 		}
 
@@ -439,8 +439,8 @@ func TestRuntimeEnvVarsForAgent(t *testing.T) {
 		if env[EnvPackFile] != defaultPackPath {
 			t.Errorf("PROMPTPACK_FILE = %q, want %q", env[EnvPackFile], defaultPackPath)
 		}
-		if env[EnvMemoryStore] != "session" {
-			t.Errorf("PROMPTPACK_MEMORY_STORE = %q, want %q", env[EnvMemoryStore], "session")
+		if env[EnvMemoryStore] != "episodic" {
+			t.Errorf("PROMPTPACK_MEMORY_STORE = %q, want %q", env[EnvMemoryStore], "episodic")
 		}
 	})
 

--- a/internal/agentcore/plan.go
+++ b/internal/agentcore/plan.go
@@ -72,13 +72,13 @@ func generateDesiredResources(pack *prompt.Pack, cfg *Config) []deploy.ResourceC
 	var desired []deploy.ResourceChange
 
 	// Memory resource (before tools/runtimes).
-	if cfg.MemoryStore != "" {
+	if cfg.HasMemory() {
 		memName := pack.ID + "_memory"
 		desired = append(desired, deploy.ResourceChange{
 			Type:   ResTypeMemory,
 			Name:   memName,
 			Action: deploy.ActionCreate,
-			Detail: fmt.Sprintf("Create memory store (%s) for %s", cfg.MemoryStore, pack.ID),
+			Detail: fmt.Sprintf("Create memory store (%s) for %s", cfg.MemoryStrategiesCSV(), pack.ID),
 		})
 	}
 

--- a/internal/agentcore/provider.go
+++ b/internal/agentcore/provider.go
@@ -24,9 +24,20 @@ const configSchema = `{
       "description": "IAM role ARN for the AgentCore runtime"
     },
     "memory_store": {
-      "type": "string",
-      "enum": ["session", "persistent"],
-      "description": "Memory store type for the agent"
+      "oneOf": [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}},
+        {
+          "type": "object",
+          "properties": {
+            "strategies": {"type": "array", "items": {"type": "string"}},
+            "event_expiry_days": {"type": "integer", "minimum": 3, "maximum": 365},
+            "encryption_key_arn": {"type": "string"}
+          },
+          "required": ["strategies"]
+        }
+      ],
+      "description": "Memory config: string, array, or object with strategies"
     },
     "tools": {
       "type": "object",


### PR DESCRIPTION
## Summary
- Replace `MemoryStore string` with `MemoryConfig` struct supporting strategies, event expiry, and encryption key
- Accept `memory_store` as string (`"episodic"`), array (`["episodic", "semantic"]`), or object with advanced options
- Support all 4 built-in strategy types: episodic, semantic, summary, user_preference
- Backward compatible: `"session"` and `"persistent"` remain valid as aliases
- Update `memoryStrategies()` to handle all types and multi-strategy memory resources
- Add `HasMemory()` and `MemoryStrategiesCSV()` helpers, update all callsites

## Test plan
- [x] Config parsing: string, array, object forms
- [x] Legacy aliases: session → episodic, persistent → semantic
- [x] Invalid strategy names → validation error
- [x] Expiry range validation (3-365)
- [x] Encryption key ARN validation
- [x] All existing tests updated and passing
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./... -race` — all pass

Closes #38