### PR TITLE
feat: add AgentCore state store wrapping data-plane SDK (#39)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 h1:WWLqlh79iO48yLkj1v
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17/go.mod h1:EhG22vHRrvF8oXSTYStZhJc1aUgKtnJe+aOiFEV90cM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.13.0 h1:hpQ9i9XakfEg/EhNZhg0SlqNeklooqXDholD3FgRx+s=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentcore v1.13.0/go.mod h1:GAqOzX7/7PQ/8B/zQM4DAzCNFPUO57Pp92YFBtVQttc=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.19.0 h1:A5xi6woj9KAUSUQk/8vioQyRV3iNwd1ovdx0mY6IenI=
 github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.19.0/go.mod h1:Lv3oChocnQdIldqajnqKxFWXupIJ8zx6vUSt/trrZZM=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.1 h1:l65dmgr7tO26EcHe6WMdseRnFLoJ2nqdkPz1nJdXfaw=

--- a/internal/agentcore/dataplane_client.go
+++ b/internal/agentcore/dataplane_client.go
@@ -1,0 +1,67 @@
+package agentcore
+
+import (
+	"context"
+	"fmt"
+
+	awscfg "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+)
+
+// DataPlaneClient abstracts the AWS Bedrock AgentCore data-plane
+// API for testing.
+type DataPlaneClient interface {
+	CreateEvent(
+		ctx context.Context,
+		input *bedrockagentcore.CreateEventInput,
+		opts ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.CreateEventOutput, error)
+
+	ListEvents(
+		ctx context.Context,
+		input *bedrockagentcore.ListEventsInput,
+		opts ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.ListEventsOutput, error)
+}
+
+// realDataPlaneClient wraps the bedrockagentcore SDK client.
+type realDataPlaneClient struct {
+	client *bedrockagentcore.Client
+}
+
+// NewDataPlaneClient creates a DataPlaneClient backed by the
+// real AWS Bedrock AgentCore data-plane SDK.
+func NewDataPlaneClient(
+	region string,
+) (DataPlaneClient, error) {
+	cfg, err := awscfg.LoadDefaultConfig(
+		context.Background(),
+		awscfg.WithRegion(region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"load AWS config for data-plane: %w", err,
+		)
+	}
+	return &realDataPlaneClient{
+		client: bedrockagentcore.NewFromConfig(cfg),
+	}, nil
+}
+
+// CreateEvent delegates to the underlying SDK client.
+func (c *realDataPlaneClient) CreateEvent(
+	ctx context.Context,
+	input *bedrockagentcore.CreateEventInput,
+	opts ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.CreateEventOutput, error) {
+	return c.client.CreateEvent(ctx, input, opts...)
+}
+
+// ListEvents delegates to the underlying SDK client.
+func (c *realDataPlaneClient) ListEvents(
+	ctx context.Context,
+	input *bedrockagentcore.ListEventsInput,
+	opts ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.ListEventsOutput, error) {
+	return c.client.ListEvents(ctx, input, opts...)
+}

--- a/internal/agentcore/statestore.go
+++ b/internal/agentcore/statestore.go
@@ -1,0 +1,401 @@
+package agentcore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+	dpTypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcore/types"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// Constants for the AgentCore state store.
+const (
+	// defaultActorID is the actor ID used for all events
+	// written by the state store.
+	defaultActorID = "promptkit"
+
+	// maxPayloadItems is the maximum number of payload items
+	// per CreateEvent call (AWS API limit).
+	maxPayloadItems = 100
+
+	// multimodalPrefix is prepended to the text content of
+	// conversational payloads that carry a JSON-encoded
+	// multimodal Message. This avoids the Smithy document
+	// limitations of PayloadTypeMemberBlob while preserving
+	// full message fidelity.
+	multimodalPrefix = "promptkit:multimodal:"
+
+	// PromptKit role constants used for SDK mapping.
+	roleUser      = "user"
+	roleAssistant = "assistant"
+	roleTool      = "tool"
+)
+
+// StateStore implements statestore.Store and
+// statestore.MessageAppender by persisting conversation
+// messages as events in an AWS Bedrock AgentCore Memory
+// resource.
+type StateStore struct {
+	memoryID    string
+	client      DataPlaneClient
+	savedCounts map[string]int
+	mu          sync.Mutex
+}
+
+// Compile-time interface checks.
+var (
+	_ statestore.Store           = (*StateStore)(nil)
+	_ statestore.MessageAppender = (*StateStore)(nil)
+)
+
+// NewStateStore creates a new StateStore.
+func NewStateStore(
+	memoryID string, client DataPlaneClient,
+) *StateStore {
+	return &StateStore{
+		memoryID:    memoryID,
+		client:      client,
+		savedCounts: make(map[string]int),
+	}
+}
+
+// Load retrieves a conversation by listing all events for
+// the given session ID.
+func (s *StateStore) Load(
+	ctx context.Context, id string,
+) (*statestore.ConversationState, error) {
+	messages, err := s.loadAllMessages(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.savedCounts[id] = len(messages)
+	s.mu.Unlock()
+
+	return &statestore.ConversationState{
+		ID:       id,
+		Messages: messages,
+	}, nil
+}
+
+// Save persists only new (delta) messages since the last
+// Load or Save for this conversation.
+func (s *StateStore) Save(
+	ctx context.Context,
+	state *statestore.ConversationState,
+) error {
+	s.mu.Lock()
+	saved := s.savedCounts[state.ID]
+	s.mu.Unlock()
+
+	if saved >= len(state.Messages) {
+		return nil
+	}
+
+	newMsgs := state.Messages[saved:]
+	if err := s.writeMessages(
+		ctx, state.ID, newMsgs,
+	); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.savedCounts[state.ID] = len(state.Messages)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// Fork copies all events from sourceID into a new session
+// newID.
+func (s *StateStore) Fork(
+	ctx context.Context, sourceID, newID string,
+) error {
+	messages, err := s.loadAllMessages(ctx, sourceID)
+	if err != nil {
+		return err
+	}
+	if len(messages) == 0 {
+		return statestore.ErrNotFound
+	}
+
+	if err := s.writeMessages(
+		ctx, newID, messages,
+	); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.savedCounts[newID] = len(messages)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// AppendMessages writes messages directly without requiring
+// a prior Load.
+func (s *StateStore) AppendMessages(
+	ctx context.Context,
+	id string,
+	messages []types.Message,
+) error {
+	if err := s.writeMessages(
+		ctx, id, messages,
+	); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.savedCounts[id] += len(messages)
+	s.mu.Unlock()
+
+	return nil
+}
+
+// ---------- internal helpers ----------
+
+// loadAllMessages fetches all events for a session, following
+// pagination, and converts them to PromptKit messages.
+func (s *StateStore) loadAllMessages(
+	ctx context.Context, sessionID string,
+) ([]types.Message, error) {
+	var allMessages []types.Message
+	var nextToken *string
+
+	for {
+		out, err := s.client.ListEvents(
+			ctx,
+			&bedrockagentcore.ListEventsInput{
+				MemoryId:  aws.String(s.memoryID),
+				NextToken: nextToken,
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"ListEvents for session %q: %w",
+				sessionID, err,
+			)
+		}
+
+		for i := range out.Events {
+			msgs := extractMessagesFromEvent(
+				&out.Events[i], sessionID,
+			)
+			allMessages = append(
+				allMessages, msgs...,
+			)
+		}
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	return allMessages, nil
+}
+
+// extractMessagesFromEvent converts a single Event's payload
+// items into PromptKit messages. Only events matching the
+// target sessionID are included.
+func extractMessagesFromEvent(
+	event *dpTypes.Event, sessionID string,
+) []types.Message {
+	if aws.ToString(event.SessionId) != sessionID {
+		return nil
+	}
+
+	var messages []types.Message
+	for _, payload := range event.Payload {
+		msg, ok := convertPayloadToMessage(payload)
+		if ok {
+			messages = append(messages, msg)
+		}
+	}
+	return messages
+}
+
+// convertPayloadToMessage maps a single PayloadType to a
+// PromptKit Message. Returns false if the payload cannot be
+// converted.
+func convertPayloadToMessage(
+	payload dpTypes.PayloadType,
+) (types.Message, bool) {
+	conv, ok := payload.(*dpTypes.PayloadTypeMemberConversational)
+	if !ok {
+		return types.Message{}, false
+	}
+	return convertConversational(conv.Value), true
+}
+
+// convertConversational maps a Conversational payload to a
+// PromptKit Message. If the text content starts with the
+// multimodal prefix, it is decoded as a full JSON Message.
+func convertConversational(
+	conv dpTypes.Conversational,
+) types.Message {
+	text := extractTextContent(conv.Content)
+
+	if strings.HasPrefix(text, multimodalPrefix) {
+		jsonStr := strings.TrimPrefix(text, multimodalPrefix)
+		var msg types.Message
+		if err := json.Unmarshal(
+			[]byte(jsonStr), &msg,
+		); err == nil {
+			return msg
+		}
+	}
+
+	role := mapRoleFromSDK(conv.Role)
+	return types.Message{Role: role, Content: text}
+}
+
+// extractTextContent extracts the text string from the
+// Content union type.
+func extractTextContent(content dpTypes.Content) string {
+	if c, ok := content.(*dpTypes.ContentMemberText); ok {
+		return c.Value
+	}
+	return ""
+}
+
+// writeMessages converts PromptKit messages to payloads and
+// writes them in batches of maxPayloadItems.
+func (s *StateStore) writeMessages(
+	ctx context.Context, sessionID string,
+	messages []types.Message,
+) error {
+	payloads := make(
+		[]dpTypes.PayloadType, 0, len(messages),
+	)
+	for i := range messages {
+		payloads = append(
+			payloads,
+			convertMessageToPayload(&messages[i]),
+		)
+	}
+
+	return s.writeBatches(ctx, sessionID, payloads)
+}
+
+// writeBatches sends payloads in chunks of maxPayloadItems.
+func (s *StateStore) writeBatches(
+	ctx context.Context, sessionID string,
+	payloads []dpTypes.PayloadType,
+) error {
+	for i := 0; i < len(payloads); i += maxPayloadItems {
+		end := i + maxPayloadItems
+		if end > len(payloads) {
+			end = len(payloads)
+		}
+
+		now := time.Now()
+		_, err := s.client.CreateEvent(
+			ctx,
+			&bedrockagentcore.CreateEventInput{
+				MemoryId:       aws.String(s.memoryID),
+				ActorId:        aws.String(defaultActorID),
+				SessionId:      aws.String(sessionID),
+				EventTimestamp: &now,
+				Payload:        payloads[i:end],
+			},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"CreateEvent for session %q: %w",
+				sessionID, err,
+			)
+		}
+	}
+	return nil
+}
+
+// convertMessageToPayload maps a PromptKit Message to an AWS
+// PayloadType. All messages use the conversational format.
+// Multimodal messages are JSON-encoded with a prefix marker
+// in the text content to preserve full fidelity.
+func convertMessageToPayload(
+	msg *types.Message,
+) dpTypes.PayloadType {
+	if msg.IsMultimodal() {
+		return messageToMultimodalPayload(msg)
+	}
+	return messageToConversational(msg)
+}
+
+// messageToMultimodalPayload encodes a multimodal Message as
+// a conversational payload with JSON in the text field,
+// prefixed by the multimodal marker.
+func messageToMultimodalPayload(
+	msg *types.Message,
+) dpTypes.PayloadType {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return messageToConversational(msg)
+	}
+	text := multimodalPrefix + string(data)
+	return &dpTypes.PayloadTypeMemberConversational{
+		Value: dpTypes.Conversational{
+			Role: mapRoleToSDK(msg.Role),
+			Content: &dpTypes.ContentMemberText{
+				Value: text,
+			},
+		},
+	}
+}
+
+// messageToConversational builds a conversational payload
+// from a text-only message.
+func messageToConversational(
+	msg *types.Message,
+) dpTypes.PayloadType {
+	return &dpTypes.PayloadTypeMemberConversational{
+		Value: dpTypes.Conversational{
+			Role: mapRoleToSDK(msg.Role),
+			Content: &dpTypes.ContentMemberText{
+				Value: msg.Content,
+			},
+		},
+	}
+}
+
+// mapRoleToSDK converts a PromptKit role string to the SDK
+// Role enum.
+func mapRoleToSDK(role string) dpTypes.Role {
+	switch role {
+	case roleUser:
+		return dpTypes.RoleUser
+	case roleAssistant:
+		return dpTypes.RoleAssistant
+	case roleTool:
+		return dpTypes.RoleTool
+	default:
+		return dpTypes.RoleOther
+	}
+}
+
+// mapRoleFromSDK converts an SDK Role enum to a PromptKit
+// role string.
+func mapRoleFromSDK(role dpTypes.Role) string {
+	switch role {
+	case dpTypes.RoleUser:
+		return roleUser
+	case dpTypes.RoleAssistant:
+		return roleAssistant
+	case dpTypes.RoleTool:
+		return roleTool
+	case dpTypes.RoleOther:
+		return string(role)
+	default:
+		return string(role)
+	}
+}

--- a/internal/agentcore/statestore_test.go
+++ b/internal/agentcore/statestore_test.go
@@ -1,0 +1,701 @@
+package agentcore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentcore"
+	dpTypes "github.com/aws/aws-sdk-go-v2/service/bedrockagentcore/types"
+
+	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+)
+
+// ---------- mock DataPlaneClient ----------
+
+type mockDataPlaneClient struct {
+	createEventFn func(
+		ctx context.Context,
+		input *bedrockagentcore.CreateEventInput,
+		opts ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.CreateEventOutput, error)
+
+	listEventsFn func(
+		ctx context.Context,
+		input *bedrockagentcore.ListEventsInput,
+		opts ...func(*bedrockagentcore.Options),
+	) (*bedrockagentcore.ListEventsOutput, error)
+
+	createCalls []*bedrockagentcore.CreateEventInput
+}
+
+func (m *mockDataPlaneClient) CreateEvent(
+	ctx context.Context,
+	input *bedrockagentcore.CreateEventInput,
+	opts ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.CreateEventOutput, error) {
+	m.createCalls = append(m.createCalls, input)
+	if m.createEventFn != nil {
+		return m.createEventFn(ctx, input, opts...)
+	}
+	return &bedrockagentcore.CreateEventOutput{}, nil
+}
+
+func (m *mockDataPlaneClient) ListEvents(
+	ctx context.Context,
+	input *bedrockagentcore.ListEventsInput,
+	opts ...func(*bedrockagentcore.Options),
+) (*bedrockagentcore.ListEventsOutput, error) {
+	if m.listEventsFn != nil {
+		return m.listEventsFn(ctx, input, opts...)
+	}
+	return &bedrockagentcore.ListEventsOutput{}, nil
+}
+
+// ---------- helpers ----------
+
+func convPayload(
+	role dpTypes.Role, text string,
+) dpTypes.PayloadType {
+	return &dpTypes.PayloadTypeMemberConversational{
+		Value: dpTypes.Conversational{
+			Role: role,
+			Content: &dpTypes.ContentMemberText{
+				Value: text,
+			},
+		},
+	}
+}
+
+func multimodalConvPayload(
+	msg types.Message,
+) dpTypes.PayloadType {
+	data, _ := json.Marshal(msg)
+	text := multimodalPrefix + string(data)
+	return &dpTypes.PayloadTypeMemberConversational{
+		Value: dpTypes.Conversational{
+			Role: mapRoleToSDK(msg.Role),
+			Content: &dpTypes.ContentMemberText{
+				Value: text,
+			},
+		},
+	}
+}
+
+func makeEvent(
+	sessionID string, payloads ...dpTypes.PayloadType,
+) dpTypes.Event {
+	return dpTypes.Event{
+		SessionId: aws.String(sessionID),
+		ActorId:   aws.String(defaultActorID),
+		MemoryId:  aws.String("mem-1"),
+		EventId:   aws.String("evt-1"),
+		Payload:   payloads,
+	}
+}
+
+// ---------- Load tests ----------
+
+func TestLoad_EmptySession(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	state, err := store.Load(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state.ID != "sess-1" {
+		t.Errorf("got ID %q, want %q", state.ID, "sess-1")
+	}
+	if len(state.Messages) != 0 {
+		t.Errorf("got %d messages, want 0", len(state.Messages))
+	}
+}
+
+func TestLoad_TextMessages(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("sess-1",
+						convPayload(dpTypes.RoleUser, "hello"),
+						convPayload(dpTypes.RoleAssistant, "hi"),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	state, err := store.Load(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(state.Messages))
+	}
+
+	tests := []struct {
+		idx     int
+		role    string
+		content string
+	}{
+		{0, "user", "hello"},
+		{1, "assistant", "hi"},
+	}
+	for _, tt := range tests {
+		msg := state.Messages[tt.idx]
+		if msg.Role != tt.role {
+			t.Errorf("msg[%d] role: got %q, want %q",
+				tt.idx, msg.Role, tt.role)
+		}
+		if msg.Content != tt.content {
+			t.Errorf("msg[%d] content: got %q, want %q",
+				tt.idx, msg.Content, tt.content)
+		}
+	}
+}
+
+func TestLoad_MultimodalMessage(t *testing.T) {
+	textVal := "multimodal text"
+	multiMsg := types.Message{
+		Role: "user",
+		Parts: []types.ContentPart{
+			{
+				Type: types.ContentTypeText,
+				Text: &textVal,
+			},
+		},
+	}
+
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("sess-1",
+						multimodalConvPayload(multiMsg),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	state, err := store.Load(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(state.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1",
+			len(state.Messages))
+	}
+	msg := state.Messages[0]
+	if msg.Role != "user" {
+		t.Errorf("role: got %q, want %q",
+			msg.Role, "user")
+	}
+	if !msg.IsMultimodal() {
+		t.Error("expected multimodal message")
+	}
+	if msg.Parts[0].Type != types.ContentTypeText {
+		t.Errorf("part type: got %q, want %q",
+			msg.Parts[0].Type, types.ContentTypeText)
+	}
+	if *msg.Parts[0].Text != "multimodal text" {
+		t.Errorf("part text: got %q, want %q",
+			*msg.Parts[0].Text, "multimodal text")
+	}
+}
+
+func TestLoad_Pagination(t *testing.T) {
+	callCount := 0
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			callCount++
+			if callCount == 1 {
+				return &bedrockagentcore.ListEventsOutput{
+					Events: []dpTypes.Event{
+						makeEvent("sess-1",
+							convPayload(
+								dpTypes.RoleUser, "page1",
+							),
+						),
+					},
+					NextToken: aws.String("token-2"),
+				}, nil
+			}
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("sess-1",
+						convPayload(
+							dpTypes.RoleAssistant, "page2",
+						),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	state, err := store.Load(context.Background(), "sess-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(state.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(state.Messages))
+	}
+	if state.Messages[0].Content != "page1" {
+		t.Errorf("msg[0]: got %q, want %q",
+			state.Messages[0].Content, "page1")
+	}
+	if state.Messages[1].Content != "page2" {
+		t.Errorf("msg[1]: got %q, want %q",
+			state.Messages[1].Content, "page2")
+	}
+	if callCount != 2 {
+		t.Errorf("got %d calls, want 2", callCount)
+	}
+}
+
+// ---------- Save tests ----------
+
+func TestSave_DeltaOnly(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("sess-1",
+						convPayload(
+							dpTypes.RoleUser, "existing",
+						),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	ctx := context.Background()
+
+	_, err := store.Load(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	state := &statestore.ConversationState{
+		ID: "sess-1",
+		Messages: []types.Message{
+			{Role: "user", Content: "existing"},
+			{Role: "assistant", Content: "new reply"},
+		},
+	}
+	if err := store.Save(ctx, state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	payloads := mock.createCalls[0].Payload
+	if len(payloads) != 1 {
+		t.Fatalf("got %d payloads, want 1", len(payloads))
+	}
+	conv, ok := payloads[0].(*dpTypes.PayloadTypeMemberConversational)
+	if !ok {
+		t.Fatal("expected conversational payload")
+	}
+	if conv.Value.Role != dpTypes.RoleAssistant {
+		t.Errorf("role: got %q, want %q",
+			conv.Value.Role, dpTypes.RoleAssistant)
+	}
+}
+
+func TestSave_NoNewMessages(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("sess-1",
+						convPayload(dpTypes.RoleUser, "hi"),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	ctx := context.Background()
+
+	_, err := store.Load(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	state := &statestore.ConversationState{
+		ID: "sess-1",
+		Messages: []types.Message{
+			{Role: "user", Content: "hi"},
+		},
+	}
+	if err := store.Save(ctx, state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if len(mock.createCalls) != 0 {
+		t.Errorf("got %d calls, want 0",
+			len(mock.createCalls))
+	}
+}
+
+func TestSave_TextPayload(t *testing.T) {
+	mock := &mockDataPlaneClient{}
+	store := NewStateStore("mem-1", mock)
+
+	state := &statestore.ConversationState{
+		ID: "sess-1",
+		Messages: []types.Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+	if err := store.Save(
+		context.Background(), state,
+	); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	payload := mock.createCalls[0].Payload[0]
+	conv, ok := payload.(*dpTypes.PayloadTypeMemberConversational)
+	if !ok {
+		t.Fatal("expected conversational payload")
+	}
+	if conv.Value.Role != dpTypes.RoleUser {
+		t.Errorf("role: got %q, want %q",
+			conv.Value.Role, dpTypes.RoleUser)
+	}
+	text, ok := conv.Value.Content.(*dpTypes.ContentMemberText)
+	if !ok {
+		t.Fatal("expected text content")
+	}
+	if text.Value != "hello" {
+		t.Errorf("text: got %q, want %q",
+			text.Value, "hello")
+	}
+}
+
+func TestSave_MultimodalPayload(t *testing.T) {
+	mock := &mockDataPlaneClient{}
+	store := NewStateStore("mem-1", mock)
+
+	textVal := "see this image"
+	state := &statestore.ConversationState{
+		ID: "sess-1",
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Parts: []types.ContentPart{
+					{
+						Type: types.ContentTypeText,
+						Text: &textVal,
+					},
+				},
+			},
+		},
+	}
+	if err := store.Save(
+		context.Background(), state,
+	); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	payload := mock.createCalls[0].Payload[0]
+	conv, ok := payload.(*dpTypes.PayloadTypeMemberConversational)
+	if !ok {
+		t.Fatal("expected conversational payload")
+	}
+	text, ok := conv.Value.Content.(*dpTypes.ContentMemberText)
+	if !ok {
+		t.Fatal("expected text content")
+	}
+	if !strings.HasPrefix(text.Value, multimodalPrefix) {
+		t.Fatalf("expected multimodal prefix, got %q",
+			text.Value)
+	}
+	jsonStr := strings.TrimPrefix(
+		text.Value, multimodalPrefix,
+	)
+	var decoded types.Message
+	if err := json.Unmarshal(
+		[]byte(jsonStr), &decoded,
+	); err != nil {
+		t.Fatalf("failed to decode multimodal JSON: %v",
+			err)
+	}
+	if decoded.Role != "user" {
+		t.Errorf("role: got %q, want %q",
+			decoded.Role, "user")
+	}
+	if !decoded.IsMultimodal() {
+		t.Error("expected decoded message to be multimodal")
+	}
+}
+
+func TestSave_Batching(t *testing.T) {
+	mock := &mockDataPlaneClient{}
+	store := NewStateStore("mem-1", mock)
+
+	totalMessages := 150
+	messages := make([]types.Message, totalMessages)
+	for i := range totalMessages {
+		messages[i] = types.Message{
+			Role:    "user",
+			Content: fmt.Sprintf("msg-%d", i),
+		}
+	}
+
+	state := &statestore.ConversationState{
+		ID:       "sess-1",
+		Messages: messages,
+	}
+	if err := store.Save(
+		context.Background(), state,
+	); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if len(mock.createCalls) != 2 {
+		t.Fatalf("got %d calls, want 2",
+			len(mock.createCalls))
+	}
+	if len(mock.createCalls[0].Payload) != maxPayloadItems {
+		t.Errorf("batch 1: got %d, want %d",
+			len(mock.createCalls[0].Payload),
+			maxPayloadItems)
+	}
+	secondBatch := totalMessages - maxPayloadItems
+	if len(mock.createCalls[1].Payload) != secondBatch {
+		t.Errorf("batch 2: got %d, want %d",
+			len(mock.createCalls[1].Payload), secondBatch)
+	}
+}
+
+// ---------- AppendMessages tests ----------
+
+func TestAppendMessages(t *testing.T) {
+	mock := &mockDataPlaneClient{}
+	store := NewStateStore("mem-1", mock)
+
+	msgs := []types.Message{
+		{Role: "user", Content: "appended"},
+	}
+	err := store.AppendMessages(
+		context.Background(), "sess-1", msgs,
+	)
+	if err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	if aws.ToString(
+		mock.createCalls[0].SessionId,
+	) != "sess-1" {
+		t.Errorf("session: got %q, want %q",
+			aws.ToString(mock.createCalls[0].SessionId),
+			"sess-1")
+	}
+}
+
+func TestAppendMessages_UpdatesSavedCount(t *testing.T) {
+	mock := &mockDataPlaneClient{}
+	store := NewStateStore("mem-1", mock)
+	ctx := context.Background()
+
+	msgs := []types.Message{
+		{Role: "user", Content: "a"},
+		{Role: "assistant", Content: "b"},
+	}
+	if err := store.AppendMessages(
+		ctx, "sess-1", msgs,
+	); err != nil {
+		t.Fatalf("AppendMessages: %v", err)
+	}
+
+	// Save with 2 old + 1 new should only write the new.
+	mock.createCalls = nil
+	state := &statestore.ConversationState{
+		ID: "sess-1",
+		Messages: []types.Message{
+			{Role: "user", Content: "a"},
+			{Role: "assistant", Content: "b"},
+			{Role: "user", Content: "c"},
+		},
+	}
+	if err := store.Save(ctx, state); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	if len(mock.createCalls[0].Payload) != 1 {
+		t.Errorf("got %d payloads, want 1",
+			len(mock.createCalls[0].Payload))
+	}
+}
+
+// ---------- Fork tests ----------
+
+func TestFork(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{
+					makeEvent("src",
+						convPayload(
+							dpTypes.RoleUser, "forked",
+						),
+						convPayload(
+							dpTypes.RoleAssistant, "reply",
+						),
+					),
+				},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	err := store.Fork(context.Background(), "src", "dst")
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("got %d calls, want 1",
+			len(mock.createCalls))
+	}
+	if aws.ToString(
+		mock.createCalls[0].SessionId,
+	) != "dst" {
+		t.Errorf("session: got %q, want %q",
+			aws.ToString(mock.createCalls[0].SessionId),
+			"dst")
+	}
+	if len(mock.createCalls[0].Payload) != 2 {
+		t.Errorf("got %d payloads, want 2",
+			len(mock.createCalls[0].Payload))
+	}
+}
+
+func TestFork_EmptySource(t *testing.T) {
+	mock := &mockDataPlaneClient{
+		listEventsFn: func(
+			_ context.Context,
+			_ *bedrockagentcore.ListEventsInput,
+			_ ...func(*bedrockagentcore.Options),
+		) (*bedrockagentcore.ListEventsOutput, error) {
+			return &bedrockagentcore.ListEventsOutput{
+				Events: []dpTypes.Event{},
+			}, nil
+		},
+	}
+
+	store := NewStateStore("mem-1", mock)
+	err := store.Fork(context.Background(), "empty", "dst")
+	if err != statestore.ErrNotFound {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+// ---------- Role mapping tests ----------
+
+func TestRoleMapping(t *testing.T) {
+	tests := []struct {
+		promptkit string
+		sdk       dpTypes.Role
+	}{
+		{"user", dpTypes.RoleUser},
+		{"assistant", dpTypes.RoleAssistant},
+		{"tool", dpTypes.RoleTool},
+		{"system", dpTypes.RoleOther},
+		{"unknown", dpTypes.RoleOther},
+	}
+	for _, tt := range tests {
+		t.Run("to_"+tt.promptkit, func(t *testing.T) {
+			got := mapRoleToSDK(tt.promptkit)
+			if got != tt.sdk {
+				t.Errorf("mapRoleToSDK(%q) = %q, want %q",
+					tt.promptkit, got, tt.sdk)
+			}
+		})
+	}
+
+	reverseTests := []struct {
+		sdk       dpTypes.Role
+		promptkit string
+	}{
+		{dpTypes.RoleUser, "user"},
+		{dpTypes.RoleAssistant, "assistant"},
+		{dpTypes.RoleTool, "tool"},
+	}
+	for _, tt := range reverseTests {
+		t.Run("from_"+string(tt.sdk), func(t *testing.T) {
+			got := mapRoleFromSDK(tt.sdk)
+			if got != tt.promptkit {
+				t.Errorf(
+					"mapRoleFromSDK(%q) = %q, want %q",
+					tt.sdk, got, tt.promptkit,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `StateStore` satisfying PromptKit's `statestore.Store` and `MessageAppender` interfaces
- Add `DataPlaneClient` interface wrapping `bedrockagentcore` SDK for testability
- Delta-only saves — only new messages since last Load/Save are written
- Batching at 100 payload items per `CreateEvent` call (AWS API limit)
- Multimodal handling: text-only messages use `conversational` payload, multimodal messages use `promptkit:multimodal:` prefixed text (lossless JSON round-trip)
- Bidirectional role mapping (user/assistant/tool/other)
- Add `bedrockagentcore` v1.13.0 dependency

## Test plan
- [x] `TestLoad_EmptySession`, `TestLoad_TextMessages`, `TestLoad_MultimodalMessage`, `TestLoad_Pagination`
- [x] `TestSave_DeltaOnly`, `TestSave_NoNewMessages`, `TestSave_TextPayload`, `TestSave_MultimodalPayload`, `TestSave_Batching`
- [x] `TestAppendMessages`, `TestAppendMessages_UpdatesSavedCount`
- [x] `TestFork`, `TestFork_EmptySource`
- [x] `TestRoleMapping` (bidirectional)
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./... -race` — all pass

Closes #39