### PR TITLE
feat: inject pack JSON into runtime via env var

### DIFF
--- a/cmd/agentcore-runtime/config.go
+++ b/cmd/agentcore-runtime/config.go
@@ -12,6 +12,7 @@ import (
 // Environment variable names.
 const (
 	envPackFile        = "PROMPTPACK_FILE"
+	envPackJSON        = "PROMPTPACK_PACK_JSON"
 	envAgentName       = "PROMPTPACK_AGENT"
 	envPort            = "PROMPTPACK_PORT"
 	envAWSRegion       = "AWS_REGION"
@@ -33,6 +34,7 @@ const defaultPort = 9000
 // runtimeConfig holds all configuration parsed from environment variables.
 type runtimeConfig struct {
 	PackFile        string
+	PackJSON        string
 	AgentName       string
 	Port            int
 	AWSRegion       string
@@ -54,6 +56,7 @@ type runtimeConfig struct {
 func loadConfig() (*runtimeConfig, error) {
 	cfg := &runtimeConfig{
 		PackFile:        os.Getenv(envPackFile),
+		PackJSON:        os.Getenv(envPackJSON),
 		AgentName:       os.Getenv(envAgentName),
 		AWSRegion:       os.Getenv(envAWSRegion),
 		MemoryStore:     os.Getenv(envMemoryStore),
@@ -68,8 +71,8 @@ func loadConfig() (*runtimeConfig, error) {
 		Port:            defaultPort,
 	}
 
-	if cfg.PackFile == "" {
-		return nil, fmt.Errorf("%s is required", envPackFile)
+	if cfg.PackFile == "" && cfg.PackJSON == "" {
+		return nil, fmt.Errorf("%s or %s is required", envPackFile, envPackJSON)
 	}
 
 	if portStr := os.Getenv(envPort); portStr != "" {

--- a/cmd/agentcore-runtime/main.go
+++ b/cmd/agentcore-runtime/main.go
@@ -19,6 +19,8 @@ import (
 const (
 	shutdownTimeout        = 10 * time.Second
 	defaultReadHeaderTmout = 10 * time.Second
+	tmpPackPath            = "/tmp/pack.json"
+	tmpPackPerm            = 0o600
 )
 
 func main() {
@@ -33,6 +35,13 @@ func run(log *slog.Logger) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
+	}
+
+	if cfg.PackJSON != "" && cfg.PackFile == "" {
+		if writeErr := os.WriteFile(tmpPackPath, []byte(cfg.PackJSON), tmpPackPerm); writeErr != nil {
+			return fmt.Errorf("write pack JSON to temp file: %w", writeErr)
+		}
+		cfg.PackFile = tmpPackPath
 	}
 
 	pack, err := prompt.LoadPack(cfg.PackFile)

--- a/internal/agentcore/apply.go
+++ b/internal/agentcore/apply.go
@@ -82,6 +82,7 @@ func (p *Provider) prepareApply(
 		return nil, fmt.Errorf("agentcore: failed to create AWS client: %w", err)
 	}
 
+	cfg.PackJSON = req.PackJSON
 	cfg.PackTools = pack.Tools
 	cfg.RuntimeEnvVars = buildRuntimeEnvVars(cfg)
 	cfg.ResourceTags = buildResourceTags(pack.ID, pack.Version, "", cfg.Tags)
@@ -159,6 +160,7 @@ func (p *Provider) applyDryRun(
 		return "", fmt.Errorf("agentcore: %w", err)
 	}
 
+	cfg.PackJSON = req.PackJSON
 	cfg.PackTools = pack.Tools
 
 	reporter := adaptersdk.NewProgressReporter(callback)

--- a/internal/agentcore/config.go
+++ b/internal/agentcore/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	A2AAuth        *A2AAuthConfig            `json:"a2a_auth,omitempty"`
 	AgentOverrides map[string]*AgentOverride `json:"agent_overrides,omitempty"`
 
+	// PackJSON holds the raw pack JSON content to inject as an env var
+	// on the runtime container. Populated at apply-time from PlanRequest.
+	// NOT serialized — it is a transient, computed field.
+	PackJSON string `json:"-"`
+
 	// RuntimeEnvVars is populated at apply-time from config fields.
 	// It is NOT serialized — it is a transient, computed field.
 	RuntimeEnvVars map[string]string `json:"-"`

--- a/internal/agentcore/envvars.go
+++ b/internal/agentcore/envvars.go
@@ -20,6 +20,7 @@ const (
 	EnvMetricsConfig   = "PROMPTPACK_METRICS_CONFIG"
 	EnvDashboardConfig = "PROMPTPACK_DASHBOARD_CONFIG"
 	EnvPackFile        = "PROMPTPACK_FILE"
+	EnvPackJSON        = "PROMPTPACK_PACK_JSON"
 	EnvAgentName       = "PROMPTPACK_AGENT"
 )
 
@@ -54,6 +55,10 @@ func buildRuntimeEnvVars(cfg *Config) map[string]string {
 	}
 
 	env[EnvPackFile] = defaultPackPath
+
+	if cfg.PackJSON != "" {
+		env[EnvPackJSON] = cfg.PackJSON
+	}
 
 	return env
 }

--- a/internal/agentcore/envvars_test.go
+++ b/internal/agentcore/envvars_test.go
@@ -131,6 +131,23 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				EnvPackFile:    defaultPackPath,
 			},
 		},
+		{
+			name: "pack JSON injected when set",
+			cfg: &Config{
+				PackJSON: `{"id":"test","prompts":{}}`,
+			},
+			want: map[string]string{
+				EnvPackFile: defaultPackPath,
+				EnvPackJSON: `{"id":"test","prompts":{}}`,
+			},
+		},
+		{
+			name: "pack JSON omitted when empty",
+			cfg:  &Config{},
+			want: map[string]string{
+				EnvPackFile: defaultPackPath,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `PROMPTPACK_PACK_JSON` env var support to the agentcore-runtime so the container can receive pack JSON without requiring a file mount
- Runtime writes the env var content to `/tmp/pack.json` on startup when `PROMPTPACK_FILE` is not set
- Deploy adapter injects `PROMPTPACK_PACK_JSON` into the runtime env vars from `PlanRequest.PackJSON`

## Motivation

The AgentCore runtime container fails immediately because it expects `/app/pack.json` but the `CreateAgentRuntime` API has no file mount option. Passing the pack as an env var avoids rebuilding the container image per deployment. AWS limits env var values to 5000 chars; the messaround pack is ~3.4KB so it fits.

## Test plan

- [x] Unit tests: runtime config accepts `PROMPTPACK_PACK_JSON` alone, both vars, or errors when both empty
- [x] Unit tests: `buildRuntimeEnvVars` includes/omits `PROMPTPACK_PACK_JSON` based on `cfg.PackJSON`
- [x] Manual: built runtime binary, ran with `PROMPTPACK_PACK_JSON` set from messaround pack — runtime resolved agent, started listening on :9000
- [x] Manual: verified `/tmp/pack.json` content matches original pack file byte-for-byte
- [x] Manual: verified `PROMPTPACK_FILE` path still works (no regression)
- [x] All 25 linters pass, full test suite passes with `-race`