### PR TITLE
fix(ci): add workflows permission to update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   update:


### PR DESCRIPTION
## Summary

- Add `workflows: write` permission to the `update-deps.yml` workflow
- Fixes `remote rejected` error when the workflow pushes changes to `.github/workflows/ci.yml`

## Context

The "Remove sibling checkout from CI" step modifies `.github/workflows/ci.yml`, but `GITHUB_TOKEN` requires explicit `workflows` permission to push changes to workflow files. Without it, `git push` fails with:

```
! [remote rejected] (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission)
```

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger `promptkit-release` dispatch for v1.3.6
- [ ] Verify the workflow completes and creates a PR successfully