### PR TITLE
fix(release): publish bare binaries so adapter install works

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,18 +23,13 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 archives:
+  # Bare binary (no tar.gz) named to match exactly what the promptarena
+  # installer downloads: promptarena-deploy-agentcore_<goos>_<goarch>.
+  # {{ .Os }}/{{ .Arch }} are the raw GOOS/GOARCH the installer computes via
+  # runtime.GOOS/runtime.GOARCH — no x86_64/title-case translation.
   - id: default
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    files:
-      - README.md
-      - LICENSE
+    formats: [binary]
+    name_template: "promptarena-deploy-agentcore_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Same fix as PromptArena-deploy-omnia#12. The promptarena installer downloads a bare binary `promptarena-deploy-agentcore_<goos>_<goarch>` and writes it directly as the executable, but `archives` emitted `.tar.gz`, so `promptarena deploy adapter install agentcore` would 404. Switch to `formats: [binary]` with a name_template matching the installer's `adapterBinaryName` (raw GOOS/GOARCH — no x86_64/title-case translation). Verified with `goreleaser check`.