### PR TITLE
ci: make the pipeline actually gate (honest sonar, always-run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'LICENSE'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'LICENSE'
 
 jobs:
   test:
@@ -18,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        go-version: ['1.26.0']
 
     steps:
     - name: Checkout code
@@ -32,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: '1.26.0'
 
     - name: Build
       run: GOWORK=off go build -o promptarena-deploy-agentcore .
@@ -52,7 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.actor != 'dependabot[bot]'
 
     steps:
     - name: Checkout code
@@ -94,6 +84,11 @@ jobs:
 
     - name: SonarCloud Scan
       uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+      with:
+        # Block on the quality gate so this job fails (not silently passes)
+        # when coverage/quality regresses.
+        args: >
+          -Dsonar.qualitygate.wait=true
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mirrors the omnia adapter fix (#19 there). agentcore's ruleset requires `SonarCloud`, but that check was hollow and deadlock-prone:

- **Sonar now waits on the quality gate** (`-Dsonar.qualitygate.wait=true`) — the job previously exited 0 even when the gate failed, so the *required* check passed on a coverage/quality regression.
- **Removed `paths-ignore`** (`*.md`, `LICENSE`) — those PRs skipped CI, so the required `SonarCloud` check never reported → deadlock. CI now always runs.
- **Lint runs for all actors** (was dependabot-skipped) so it's requireable without deadlocking dependabot.
- **Flattened the single-element Go matrix** → stable `Test` check name.

`aws_client_real.go` stays coverage-excluded (integration-tested, not unit-tested in CI).

Paired with a ruleset update: require **Test + Lint + SonarCloud** (was SonarCloud only) and add a **Dependabot bypass** — clearing the dependabot deadlock that forced manual merges on #68–72.