### PR TITLE
docs: standardize contributor docs (DCO/CLA, PR + docs templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,26 @@
+---
+name: Documentation improvement
+about: Suggest improvements to documentation
+title: '[DOCS] '
+labels: ['documentation']
+assignees: ''
+---
+
+## Documentation issue
+
+**Location** (file / section / URL):
+
+**What's wrong, unclear, or missing?**
+
+## Proposed improvement
+
+Describe how the documentation should be improved. Include suggested wording or examples if you have them.
+
+## Contribution
+
+- [ ] I'd like to submit a PR with the fix
+- [ ] I'm reporting it for someone else to fix
+
+## Checklist
+- [ ] I searched existing issues to avoid duplicates
+- [ ] I identified the specific documentation location

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+**Type of change**
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] CI / infrastructure
+- [ ] Refactor / tests
+
+**What & why**
+What does this PR do, and why? Link any related issues.
+
+Fixes #(issue)
+
+## Testing
+- [ ] `make test` passes locally
+- [ ] `make lint` passes locally
+- [ ] Added or updated tests covering the change
+- [ ] Existing tests pass
+
+## Checklist
+- [ ] My commits are signed off (`git commit -s`) — the DCO check is enforced
+- [ ] I have signed the CLA (the CLA Assistant bot prompts on your first PR)
+- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [ ] Documentation updated if behavior changed
+- [ ] PR title follows Conventional Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ This adds a "Signed-off-by" line to your commit message:
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
+> **This is enforced.** A required `DCO` check verifies every commit in your pull request carries a matching `Signed-off-by` line. If you forget, fix it with `git commit --amend -s` (single commit) or `git rebase --signoff main` (multiple commits), then force-push.
+
+## Contributor License Agreement (CLA)
+
+Before your first contribution can be merged you must sign our Contributor License Agreement. When you open your first pull request, the **CLA Assistant** bot comments with a link to the CLA; you sign by replying on the PR with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+You sign **once** — the signature then applies to your future contributions across AltairaLabs repositories. The CLA is a **license grant**, not a copyright assignment: you keep ownership of your contribution and grant AltairaLabs a license to use and relicense it. You can read the full text [here](https://gist.github.com/chaholl/59e308a6c25cedeb6d1787aec2c70bcd).
+
 ## How to Contribute
 
 ### Reporting Bugs


### PR DESCRIPTION
## Summary

Standardize contributor docs to match the canonical AltairaLabs set.

**What & why**
- **CONTRIBUTING.md** — add the enforced DCO blockquote after the `Signed-off-by` example, and a new **Contributor License Agreement (CLA)** section after the DCO section (CLA Assistant flow, sign-once, license-grant-not-assignment, links the CLA gist).
- **.github/pull_request_template.md** — added (repo had none).
- **.github/ISSUE_TEMPLATE/documentation.md** — added (repo lacked a docs issue template). Existing bug_report.md, feature_request.md, config.yml left unchanged.

## Checklist
- [x] My commits are signed off (`git commit -s`) — the DCO check is enforced
- [x] PR title follows Conventional Commits
