### PR TITLE
fix(ci): drop invalid workflows:write permission (startup-fails every push)

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   update:


### PR DESCRIPTION
`update-deps.yml` declared `permissions: workflows: write` — but `workflows` is **not a valid permissions scope**. GitHub validates every workflow file on each push, so the invalid key made `update-deps.yml` **startup-fail on every commit** (failed run, no jobs, no log) — the "every commit triggers a CI failure" you saw. Removing the invalid key (keeping `contents`/`pull-requests: write`, which the PR-creation step needs).

Note: the workflow is `repository_dispatch`-only (PromptKit release), so it shouldn't run on push at all — this just stops the failed startup runs. Latent follow-up: its sibling-checkout-removal steps modify `.github/workflows/*`, which `GITHUB_TOKEN` can't push regardless; that path needs a PAT with `workflow` scope if/when it's actually dispatched.