### PR TITLE
fix: use published PromptKit modules, drop local replace directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Checkout PromptKit (sibling)
-      run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
-
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
@@ -47,9 +44,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Checkout PromptKit (sibling)
-      run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Checkout PromptKit (sibling)
-      run: git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/AltairaLabs/PromptKit.git ../promptkit
-
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/AltairaLabs/promptarena-deploy-agentcore
 go 1.26.0
 
 require (
-	github.com/AltairaLabs/PromptKit/runtime v1.3.5
-	github.com/AltairaLabs/PromptKit/sdk v1.3.2
-	github.com/AltairaLabs/PromptKit/server/a2a v1.3.2
+	github.com/AltairaLabs/PromptKit/runtime v1.5.2
+	github.com/AltairaLabs/PromptKit/sdk v1.5.2
+	github.com/AltairaLabs/PromptKit/server/a2a v1.5.2
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.23
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.38.4
@@ -19,7 +19,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	github.com/AltairaLabs/PromptKit/pkg v1.3.2 // indirect
+	github.com/AltairaLabs/PromptKit/pkg v1.5.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
@@ -99,11 +99,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-replace github.com/AltairaLabs/PromptKit/runtime => ../promptkit/runtime
-
-replace github.com/AltairaLabs/PromptKit/pkg => ../promptkit/pkg
-
-replace github.com/AltairaLabs/PromptKit/sdk => ../promptkit/sdk
-
-replace github.com/AltairaLabs/PromptKit/server/a2a => ../promptkit/server/a2a

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,13 @@
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+github.com/AltairaLabs/PromptKit/pkg v1.5.2 h1:vvTbCsBTduuHVuRGptAnF7Ktr/0pVk9D2ut0iC3iSuU=
+github.com/AltairaLabs/PromptKit/pkg v1.5.2/go.mod h1:rptlFxs6zCsuFAwb7yPcRQD1OLqatbQV7fopq0eW1f4=
+github.com/AltairaLabs/PromptKit/runtime v1.5.2 h1:ApzHYsT4WE/NR1YzAyOpJ+vKlYzMvxfgHKopMIqdEWI=
+github.com/AltairaLabs/PromptKit/runtime v1.5.2/go.mod h1:dkr0xMPWXhhw8AYWAkCdFf8LmyEW0C86RlC4S5r6A9U=
+github.com/AltairaLabs/PromptKit/sdk v1.5.2 h1:Z6VVQ2G0BW2iWMTLeMG9LlJuKtk8n44mn7XDDuKKHZ8=
+github.com/AltairaLabs/PromptKit/sdk v1.5.2/go.mod h1:h5rt7nb5N/WAMs0QN5sf34LXtYhsDtxeK99bdOBdSII=
+github.com/AltairaLabs/PromptKit/server/a2a v1.5.2 h1:H7Kzcg2UGoiKkBOoelsIZ6WmiDXzPLjIjCm2egKgKUo=
+github.com/AltairaLabs/PromptKit/server/a2a v1.5.2/go.mod h1:fYo4QyHTFhtOiBWACTkzxlPk4Ol9X0mtL813kj27zkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 h1:aokoqcHvaGjiM3VpjKDfMMnF/8epJ+Q1HLJ7CudztqE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0/go.mod h1:/WYEx9pcM9Y+Dd/APJaNlSvVSvzl54rrMdZT5+Oi2LM=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=


### PR DESCRIPTION
Fixes the broken CI on `main`: `go.mod` carried local-path `replace` directives (`../promptkit/*`) and phantom versions (`server/a2a v1.3.2` was never published), so `go build`/`go mod tidy` failed everywhere except a dev machine with a sibling promptkit checkout — CI reported *"updates to go.mod needed"* and golangci-lint *"no go files to analyze"*.

Removes the replaces and pins all four PromptKit modules to published **v1.5.2** (runtime, sdk, server/a2a, pkg).

Verified locally: `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run` all pass (0 issues).